### PR TITLE
Refactor conversation storage and loading system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binary
-critic
+/critic
 critic.bin
 
 # Build artifacts

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,13 +6,12 @@ import (
 	"os/exec"
 	"strings"
 
-	"git.15b.it/eno/critic/internal/comments"
 	"git.15b.it/eno/critic/internal/config"
-	"git.15b.it/eno/critic/pkg/messaging"
 	"git.15b.it/eno/critic/internal/git"
 	"git.15b.it/eno/critic/internal/logger"
 	"git.15b.it/eno/critic/internal/messagedb"
 	"git.15b.it/eno/critic/internal/ui"
+	"git.15b.it/eno/critic/pkg/critic"
 	ctypes "git.15b.it/eno/critic/pkg/types"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -21,7 +20,6 @@ import (
 // Args represents parsed command-line arguments
 type Args struct {
 	Bases      []string // List of base points (e.g., ["main", "origin/main", "HEAD"])
-	Current    string   // Current target (e.g., "current" or a git ref)
 	Paths      []string // Paths to diff
 	Extensions []string // File extensions to include
 }
@@ -96,26 +94,22 @@ func Run(args *Args) error {
 
 // Model represents the main application model
 type Model struct {
-	fileList       ui.FileListModel
-	diffView       ui.DiffViewModel
-	commentEditor  ui.CommentEditor
-	layout         ui.LayoutModel
-	diff           *ctypes.Diff
-	bases          []string              // List of base refs
-	current        string                // Current target ref
-	currentBase    int                   // Index of current base
-	paths          []string              // Paths to diff
-	extensions     []string              // File extensions to include
-	resolver       *git.BaseResolver     // Base resolver with polling
-	watcher        *git.Watcher
-	commentManager *comments.FileManager // Manages comment files
-	messaging      messaging.Messaging      // Messaging interface for conversations
-	err            error
-	width          int
-	height         int
-	ready          bool
-	reloading      bool
-	showHelp       bool // Whether to show help screen
+	fileList      ui.FileListModel
+	diffView      ui.DiffViewModel
+	commentEditor ui.CommentEditor
+	layout        ui.LayoutModel
+	diff          *ctypes.Diff
+	bases         []string          // List of base refs
+	currentBase   int               // Index of current base
+	paths         []string          // Paths to diff
+	extensions    []string          // File extensions to include
+	resolver      *git.BaseResolver // Base resolver with polling
+	messaging     critic.Messaging  // Messaging interface for conversations
+	err           error
+	width         int
+	height        int
+	ready         bool
+	showHelp      bool // Whether to show help screen
 }
 
 // NewModel creates a new application model
@@ -124,27 +118,8 @@ func NewModel(args *Args) Model {
 	diffView := ui.NewDiffViewModel()
 	diffView.SetHighlightingEnabled(true) // Always enable highlighting
 
-	// Only initialize file watcher when diffing against "current"
-	var watcher *git.Watcher
-	if args.Current == "current" {
-		w, err := git.NewWatcher(100) // 100ms debounce
-		if err != nil {
-			logger.Fatal("Failed to create file watcher: %v", err)
-		}
-		logger.Info("NewModel: Watcher created for 'current' mode")
-		watcher = w
-	} else {
-		logger.Info("NewModel: No watcher (diffing against %s, not 'current')", args.Current)
-	}
-
 	fileList := ui.NewFileListModel()
 	fileList.SetFocused(true) // Start with file list focused
-
-	// Initialize comment manager
-	cwd, _ := os.Getwd()
-	commentManager := comments.NewFileManager(cwd, args.Current)
-	fileList.SetCommentManager(commentManager)
-	diffView.SetCommentManager(commentManager)
 
 	// Initialize message database
 	gitRoot, err := git.GetGitRoot()
@@ -159,18 +134,15 @@ func NewModel(args *Args) Model {
 	fileList.SetMessaging(mdb)
 
 	return Model{
-		fileList:       fileList,
-		diffView:       diffView,
-		commentEditor:  ui.NewCommentEditor(),
-		layout:         ui.NewLayoutModel(),
-		bases:          args.Bases,
-		current:        args.Current,
-		currentBase:    0, // Start with first base
-		paths:          args.Paths,
-		extensions:     args.Extensions,
-		watcher:        watcher,
-		commentManager: commentManager,
-		messaging:      mdb,
+		fileList:      fileList,
+		diffView:      diffView,
+		commentEditor: ui.NewCommentEditor(),
+		layout:        ui.NewLayoutModel(),
+		bases:         args.Bases,
+		currentBase:   0, // Start with first base
+		paths:         args.Paths,
+		extensions:    args.Extensions,
+		messaging:     mdb,
 	}
 }
 
@@ -185,19 +157,6 @@ func (m Model) Init() tea.Cmd {
 		initBaseResolverCmd(&m),
 		loadDiffCmd(&m),
 		disableTerminalLineWrap, // This now handles alternate screen + nowrap
-	}
-
-	// Start file watcher if available
-	if m.watcher != nil {
-		logger.Info("Init: Starting file watcher")
-		if err := m.watcher.WatchPaths(m.paths); err == nil {
-			logger.Info("Init: WatchPaths succeeded, starting waitForFileChanges")
-			cmds = append(cmds, waitForFileChanges(m.watcher))
-		} else {
-			logger.Error("Init: WatchPaths failed: %v", err)
-		}
-	} else {
-		logger.Info("Init: No watcher available")
 	}
 
 	return tea.Batch(cmds...)
@@ -265,15 +224,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					if isCommentLine {
 						// Cursor is on a comment preview line - edit that comment
 						lineNum = sourceLine
-						// Load the existing comment from file
-						gitPath := activeFile.NewPath
-						if activeFile.IsDeleted {
-							gitPath = activeFile.OldPath
-						}
-						if criticFile, err := m.commentManager.LoadComments(gitPath); err == nil {
-							if comment, exists := criticFile.Comments[lineNum]; exists {
-								// Join all comment lines with newlines
-								existingComment = strings.Join(comment.Lines, "\n")
+						// Load the existing comment from the messaging interface
+						uuid := m.diffView.GetConversationUUIDAtLine(cursorLine)
+						if uuid != "" {
+							if conv, err := m.messaging.GetFullConversation(uuid); err == nil && len(conv.Messages) > 0 {
+								// Get the last message from the conversation
+								lastMsg := conv.Messages[len(conv.Messages)-1]
+								existingComment = lastMsg.Message
 							}
 						}
 					} else {
@@ -361,42 +318,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			logger.Error("Update: Diff loading failed: %v", m.err)
 		}
 
-	case fileChangedMsg:
-		// Check if the changed file is currently being viewed
-		activeFile := m.fileList.GetActiveFile()
-		if activeFile != nil {
-			// Get the git-relative path of the currently viewed file
-			currentGitPath := activeFile.NewPath
-			if currentGitPath == "" {
-				currentGitPath = activeFile.OldPath
-			}
-
-			// Convert watcher absolute path to git-relative path
-			changedGitPath := git.AbsPathToGitPath(msg.path)
-
-			logger.Info("Update: File changed: watcher=%q -> git=%q, active=%q", msg.path, changedGitPath, currentGitPath)
-
-			// Compare git-relative paths
-			if changedGitPath != "" && changedGitPath == currentGitPath {
-				logger.Info("Update: MATCH! Changed file is currently viewed, immediately re-rendering")
-				// Immediately re-render the current file
-				cmd := m.diffView.SetFile(activeFile)
-				cmds = append(cmds, cmd)
-			} else {
-				logger.Info("Update: No match - changed file is not currently viewed")
-			}
-		}
-
-		// Also reload the full diff in the background to update file list
-		logger.Info("Update: Reloading full diff in background")
-		m.reloading = true
-		return m, tea.Batch(
-			append(cmds,
-				loadDiffCmd(&m),
-				waitForFileChanges(m.watcher),
-			)...,
-		)
-
 	case baseResolverInitializedMsg:
 		logger.Info("Update: BaseResolver initialized")
 		m.resolver = msg.resolver
@@ -408,9 +329,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, loadDiffCmd(&m)
 
 	case ui.CommentSavedMsg:
-		// Save the comment to file
+		// Save the comment using the messaging interface
 		activeFile := m.fileList.GetActiveFile()
-		if activeFile != nil {
+		if activeFile != nil && msg.Comment != "" {
 			filePath := activeFile.NewPath
 			if filePath == "" {
 				filePath = activeFile.OldPath
@@ -419,70 +340,41 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Get current git commit for code_version
 			codeVersion := m.getCurrentCodeVersion()
 
-			// Load existing comments
-			criticFile, err := m.commentManager.LoadComments(filePath)
-			if err != nil {
-				logger.Error("Failed to load comments: %v", err)
+			// Get the cursor line to check for existing conversation
+			cursorLine := m.diffView.GetCursorLine()
+			existingUUID := m.diffView.GetConversationUUIDAtLine(cursorLine)
+
+			if existingUUID != "" {
+				// There's an existing conversation - add a reply
+				replyMsg, err := m.messaging.ReplyToConversation(
+					existingUUID,
+					msg.Comment,
+					critic.AuthorHuman,
+				)
+				if err != nil {
+					logger.Error("Failed to create reply: %v", err)
+					return m, nil
+				}
+				logger.Info("Created reply %s to conversation %s", replyMsg.UUID, existingUUID)
 			} else {
-				// Add the comment (create conversation or reply)
-				if msg.Comment != "" {
-					// Check if there's an existing conversation at this line
-					existingBlock := criticFile.Comments[msg.LineNum]
-
-					var conversationUUID string
-
-					if existingBlock != nil && existingBlock.UUID != "" {
-						// There's an existing conversation - add a reply
-						replyMsg, err := m.messaging.ReplyToConversation(
-							existingBlock.UUID,
-							msg.Comment,
-							messaging.AuthorHuman,
-						)
-						if err != nil {
-							logger.Error("Failed to create reply: %v", err)
-							return m, nil
-						}
-						conversationUUID = existingBlock.UUID
-						logger.Info("Created reply %s to conversation %s", replyMsg.UUID, conversationUUID)
-					} else {
-						// No existing conversation - create a new one
-						conversation, err := m.messaging.CreateConversation(
-							messaging.AuthorHuman,
-							msg.Comment,
-							filePath,
-							msg.LineNum,
-							codeVersion,
-						)
-						if err != nil {
-							logger.Error("Failed to create conversation: %v", err)
-							return m, nil
-						}
-						conversationUUID = conversation.UUID
-						logger.Info("Created conversation %s at %s:%d", conversationUUID, filePath, msg.LineNum)
-
-						// Only update the critic file for NEW conversations
-						// For replies, the conversation UUID stays the same
-						criticFile.Comments[msg.LineNum] = &ctypes.CriticBlock{
-							LineNumber: msg.LineNum,
-							Lines:      strings.Split(msg.Comment, "\n"),
-							UUID:       conversationUUID,
-						}
-					}
-				} else {
-					// Empty comment means delete
-					delete(criticFile.Comments, msg.LineNum)
+				// No existing conversation - create a new one
+				conversation, err := m.messaging.CreateConversation(
+					critic.AuthorHuman,
+					msg.Comment,
+					filePath,
+					msg.LineNum,
+					codeVersion,
+				)
+				if err != nil {
+					logger.Error("Failed to create conversation: %v", err)
+					return m, nil
 				}
-
-				// Save the updated comments
-				if err := m.commentManager.SaveComments(criticFile); err != nil {
-					logger.Error("Failed to save comments: %v", err)
-				} else {
-					logger.Info("Comment saved for line %d", msg.LineNum)
-					// Force refresh the diff view to show the new/updated comment inline
-					cmd := m.diffView.RefreshFile()
-					cmds = append(cmds, cmd)
-				}
+				logger.Info("Created conversation %s at %s:%d", conversation.UUID, filePath, msg.LineNum)
 			}
+
+			// Force refresh the diff view to show the new/updated comment inline
+			cmd := m.diffView.RefreshFile()
+			cmds = append(cmds, cmd)
 		}
 
 
@@ -564,10 +456,10 @@ func (m Model) View() string {
 func (m Model) renderStatusBar() string {
 	var parts []string
 
-	// Show current base and target
+	// Show current base
 	if len(m.bases) > 0 {
 		base := m.bases[m.currentBase]
-		parts = append(parts, fmt.Sprintf("[B]ase: %s → %s", base, m.current))
+		parts = append(parts, fmt.Sprintf("[B]ase: %s → HEAD", base))
 	}
 
 	// Show file count
@@ -607,10 +499,6 @@ func renderError(err error) string {
 type diffLoadedMsg struct {
 	diff *ctypes.Diff
 	err  error
-}
-
-type fileChangedMsg struct {
-	path string
 }
 
 type baseResolverInitializedMsg struct {
@@ -668,7 +556,7 @@ func enableTerminalLineWrap() tea.Msg {
 
 func initBaseResolverCmd(m *Model) tea.Cmd {
 	return func() tea.Msg {
-		resolver, err := git.NewBaseResolver(m.bases, m.current, func() {
+		resolver, err := git.NewBaseResolver(m.bases, "HEAD", func() {
 			// This callback is called when bases change
 			// We'll send a message to trigger reload
 			logger.Info("BaseResolver: Bases changed, triggering reload")
@@ -709,20 +597,13 @@ func loadDiffCmd(m *Model) tea.Cmd {
 			baseCommit = resolvedSHA
 		}
 
-		// Resolve target (might be "current" or a git ref)
-		var targetCommit string
-		if m.current == "current" {
-			targetCommit = "current"
-		} else {
-			// Resolve target ref to commit SHA
-			sha, err := git.ResolveRef(m.current)
-			if err != nil {
-				return diffLoadedMsg{diff: nil, err: fmt.Errorf("failed to resolve target %s: %w", m.current, err)}
-			}
-			targetCommit = sha
+		// Always diff against HEAD
+		targetCommit, err := git.ResolveRef("HEAD")
+		if err != nil {
+			return diffLoadedMsg{diff: nil, err: fmt.Errorf("failed to resolve HEAD: %w", err)}
 		}
 
-		logger.Info("loadDiffCmd: Loading diff from %s (%s) to %s (%s)", baseName, baseCommit, m.current, targetCommit)
+		logger.Info("loadDiffCmd: Loading diff from %s (%s) to HEAD (%s)", baseName, baseCommit, targetCommit)
 
 		// Use GetDiffBetween to get diff between specific commits
 		diff, err := git.GetDiffBetween(baseCommit, targetCommit, m.paths)
@@ -753,20 +634,6 @@ func resolveBase(base string) (string, error) {
 	}
 
 	return mergeBase, nil
-}
-
-func waitForFileChanges(watcher *git.Watcher) tea.Cmd {
-	if watcher == nil {
-		logger.Info("waitForFileChanges: No watcher, returning nil")
-		return nil
-	}
-
-	return func() tea.Msg {
-		logger.Info("waitForFileChanges: Waiting for file changes...")
-		change := <-watcher.Changes()
-		logger.Info("waitForFileChanges: File change received for %s, returning fileChangedMsg", change.Path)
-		return fileChangedMsg{path: change.Path}
-	}
 }
 
 // renderHelpOverlay renders the help screen overlay

--- a/internal/cli/convo.go
+++ b/internal/cli/convo.go
@@ -6,7 +6,7 @@ import (
 
 	"git.15b.it/eno/critic/internal/git"
 	"git.15b.it/eno/critic/internal/messagedb"
-	"git.15b.it/eno/critic/pkg/messaging"
+	"git.15b.it/eno/critic/pkg/critic"
 	"github.com/spf13/cobra"
 )
 
@@ -174,7 +174,7 @@ Example:
 				}
 
 				author := "human"
-				if msg.Author == messaging.AuthorAI {
+				if msg.Author == critic.AuthorAI {
 					author = "ai"
 				}
 
@@ -213,12 +213,12 @@ Examples:
 			message := args[1]
 
 			// Validate author
-			var msgAuthor messaging.Author
+			var msgAuthor critic.Author
 			switch author {
 			case "human":
-				msgAuthor = messaging.AuthorHuman
+				msgAuthor = critic.AuthorHuman
 			case "ai":
-				msgAuthor = messaging.AuthorAI
+				msgAuthor = critic.AuthorAI
 			default:
 				return fmt.Errorf("invalid author: %s (must be 'human' or 'ai')", author)
 			}

--- a/internal/cli/parser.go
+++ b/internal/cli/parser.go
@@ -44,18 +44,17 @@ func newRootCmd(handler func(*app.Args) error) *cobra.Command {
 	var extensionsFlag []string
 
 	cmd := &cobra.Command{
-		Use:   "critic [flags] [base1,base2..current] [-- path1 path2 ...]",
+		Use:   "critic [flags] [base1,base2,...] [-- path1 path2 ...]",
 		Short: "Critic - Git diff viewer with side-by-side comparison",
 		Long: `Critic is a terminal-based git diff viewer that shows changes side-by-side.
 
 Syntax:
-  critic [base1,base2,base3..current] [-- path1 path2 path3]
+  critic [base1,base2,base3] [-- path1 path2 path3]
 
 Examples:
   critic                           # Compare against default bases (main/master, origin/<branch>, HEAD)
-  critic main..current             # Compare main branch to working directory
-  critic main,develop..current     # Compare against multiple bases
-  critic HEAD~1..HEAD              # Compare two commits
+  critic main                      # Compare main branch to HEAD
+  critic main,develop              # Compare against multiple bases
   critic -- src tests              # Only show changes in src and tests directories
   critic --extensions=go,rs        # Only show .go and .rs files
 `,
@@ -83,7 +82,6 @@ Examples:
 			parsedArgs := &app.Args{
 				Extensions: ensureSlice(extensionsFlag),
 				Paths:      []string{"."},
-				Current:    "current", // Default to working directory
 			}
 
 			// Get paths after -- separator
@@ -91,7 +89,7 @@ Examples:
 			var baseArg string
 			if argsLenAtDash >= 0 {
 				// There was a -- separator
-				// The base..current arg is before --
+				// The bases arg is before --
 				if argsLenAtDash > 0 {
 					baseArg = args[0]
 				}
@@ -107,11 +105,9 @@ Examples:
 				}
 			}
 
-			// Parse base..current syntax
+			// Parse bases
 			if baseArg != "" {
-				if err := parseBasesCurrent(baseArg, parsedArgs); err != nil {
-					return err
-				}
+				parsedArgs.Bases = strings.Split(baseArg, ",")
 			}
 
 			// Call the command handler
@@ -132,25 +128,3 @@ func ensureSlice(s []string) []string {
 	}
 	return s
 }
-
-// parseBasesCurrent parses the "base1,base2,base3..current" syntax
-func parseBasesCurrent(arg string, result *app.Args) error {
-	parts := strings.Split(arg, "..")
-
-	if len(parts) > 2 {
-		return fmt.Errorf("invalid base..current syntax: too many '..' separators")
-	}
-
-	// Parse bases (before ..)
-	if parts[0] != "" {
-		result.Bases = strings.Split(parts[0], ",")
-	}
-
-	// Parse current (after ..)
-	if len(parts) == 2 && parts[1] != "" {
-		result.Current = parts[1]
-	}
-
-	return nil
-}
-

--- a/internal/cli/parser_test.go
+++ b/internal/cli/parser_test.go
@@ -19,7 +19,6 @@ func TestParse(t *testing.T) {
 			args: []string{},
 			expected: &app.Args{
 				Bases:      nil, // No bases specified - app layer will add defaults
-				Current:    "current",
 				Paths:      []string{"."},
 				Extensions: []string{}, // No extensions specified - app layer will add defaults
 			},
@@ -29,80 +28,50 @@ func TestParse(t *testing.T) {
 			args: []string{"--extensions=go,rs"},
 			expected: &app.Args{
 				Bases:      nil, // No bases specified - app layer will add defaults
-				Current:    "current",
 				Paths:      []string{"."},
 				Extensions: []string{"go", "rs"},
 			},
 		},
 		{
-			name: "Single base to current",
-			args: []string{"main..current"},
+			name: "Single base",
+			args: []string{"main"},
 			expected: &app.Args{
 				Bases:      []string{"main"},
-				Current:    "current",
 				Paths:      []string{"."},
 				Extensions: []string{},
 			},
 		},
 		{
-			name: "Multiple bases to current",
-			args: []string{"merge-base,origin/main,HEAD..current"},
+			name: "Multiple bases",
+			args: []string{"merge-base,origin/main,HEAD"},
 			expected: &app.Args{
 				Bases:      []string{"merge-base", "origin/main", "HEAD"},
-				Current:    "current",
-				Paths:      []string{"."},
-				Extensions: []string{},
-			},
-		},
-		{
-			name: "Bases to specific ref",
-			args: []string{"main,develop..v1.0.0"},
-			expected: &app.Args{
-				Bases:      []string{"main", "develop"},
-				Current:    "v1.0.0",
 				Paths:      []string{"."},
 				Extensions: []string{},
 			},
 		},
 		{
 			name: "With explicit paths",
-			args: []string{"main..current", "--", "src", "tests"},
+			args: []string{"main", "--", "src", "tests"},
 			expected: &app.Args{
 				Bases:      []string{"main"},
-				Current:    "current",
 				Paths:      []string{"src", "tests"},
 				Extensions: []string{},
 			},
 		},
 		{
 			name: "Extensions and paths",
-			args: []string{"--extensions=go,rs", "main..current", "--", "src"},
+			args: []string{"--extensions=go,rs", "main", "--", "src"},
 			expected: &app.Args{
 				Bases:      []string{"main"},
-				Current:    "current",
 				Paths:      []string{"src"},
 				Extensions: []string{"go", "rs"},
-			},
-		},
-		{
-			name: "Just bases (no current specified)",
-			args: []string{"main,develop"},
-			expected: &app.Args{
-				Bases:      []string{"main", "develop"},
-				Current:    "current", // Default
-				Paths:      []string{"."},
-				Extensions: []string{},
 			},
 		},
 		{
 			name:          "Unknown flag",
 			args:          []string{"--unknown"},
 			expectedError: "unknown",
-		},
-		{
-			name:          "Too many .. separators",
-			args:          []string{"a..b..c"},
-			expectedError: "too many '..' separators",
 		},
 	}
 
@@ -117,65 +86,7 @@ func TestParse(t *testing.T) {
 
 			assert.Equals(t, actual.Extensions, tt.expected.Extensions)
 			assert.Equals(t, actual.Bases, tt.expected.Bases)
-			assert.Equals(t, actual.Current, tt.expected.Current)
 			assert.Equals(t, actual.Paths, tt.expected.Paths)
-		})
-	}
-}
-
-func TestParseBasesCurrent(t *testing.T) {
-	tests := []struct {
-		name            string
-		arg             string
-		expectedBases   []string
-		expectedCurrent string
-		expectedError   string
-	}{
-		{
-			name:            "Single base",
-			arg:             "main..current",
-			expectedBases:   []string{"main"},
-			expectedCurrent: "current",
-		},
-		{
-			name:            "Multiple bases",
-			arg:             "a,b,c..current",
-			expectedBases:   []string{"a", "b", "c"},
-			expectedCurrent: "current",
-		},
-		{
-			name:            "No current (just bases)",
-			arg:             "main,develop",
-			expectedBases:   []string{"main", "develop"},
-			expectedCurrent: "current", // Default
-		},
-		{
-			name:            "Empty bases",
-			arg:             "..current",
-			expectedBases:   nil,
-			expectedCurrent: "current",
-		},
-		{
-			name:          "Too many separators",
-			arg:           "a..b..c",
-			expectedError: "too many '..' separators",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			actual := &app.Args{
-				Current: "current", // Default
-			}
-			err := parseBasesCurrent(tt.arg, actual)
-			if tt.expectedError != "" {
-				assert.Error(t, err, tt.expectedError)
-				return
-			}
-			assert.NoError(t, err)
-
-			assert.Equals(t, actual.Bases, tt.expectedBases)
-			assert.Equals(t, actual.Current, tt.expectedCurrent)
 		})
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"strings"
 
-	"git.15b.it/eno/critic/pkg/messaging"
 	"git.15b.it/eno/critic/internal/git"
 	"git.15b.it/eno/critic/internal/logger"
 	"git.15b.it/eno/critic/internal/messagedb"
+	"git.15b.it/eno/critic/pkg/critic"
 )
 
 const (
@@ -27,7 +27,7 @@ const (
 type Server struct {
 	reader      *bufio.Reader
 	writer      io.Writer
-	messaging   messaging.Messaging
+	messaging   critic.Messaging
 	initialized bool
 }
 
@@ -54,7 +54,7 @@ func NewServer() *Server {
 }
 
 // SetMessaging sets the messaging interface
-func (s *Server) SetMessaging(messaging messaging.Messaging) {
+func (s *Server) SetMessaging(messaging critic.Messaging) {
 	s.messaging = messaging
 }
 
@@ -284,7 +284,7 @@ func (s *Server) handleReplyToCriticConversation(req Request, params CallToolPar
 
 	s.logToStderr("Adding reply to conversation %s", uuid)
 
-	reply, err := s.messaging.ReplyToConversation(uuid, message, messaging.AuthorAI)
+	reply, err := s.messaging.ReplyToConversation(uuid, message, critic.AuthorAI)
 	if err != nil {
 		s.logToStderr("Failed to create reply: %v", err)
 		return s.sendToolError(req.ID, fmt.Sprintf("Error creating reply: %v", err))
@@ -295,7 +295,7 @@ func (s *Server) handleReplyToCriticConversation(req Request, params CallToolPar
 }
 
 // formatConversation formats a conversation for display
-func (s *Server) formatConversation(conv *messaging.Conversation) string {
+func (s *Server) formatConversation(conv *critic.Conversation) string {
 	var builder strings.Builder
 
 	// Header with metadata
@@ -312,7 +312,7 @@ func (s *Server) formatConversation(conv *messaging.Conversation) string {
 		}
 
 		prefix := "human"
-		if msg.Author == messaging.AuthorAI {
+		if msg.Author == critic.AuthorAI {
 			prefix = "ai"
 		}
 

--- a/internal/messagedb/messaging.go
+++ b/internal/messagedb/messaging.go
@@ -3,12 +3,12 @@ package messagedb
 import (
 	"fmt"
 
-	"git.15b.it/eno/critic/pkg/messaging"
 	"git.15b.it/eno/critic/internal/logger"
+	"git.15b.it/eno/critic/pkg/critic"
 )
 
-// Ensure DB implements the messaging.Messaging interface
-var _ messaging.Messaging = (*DB)(nil)
+// Ensure DB implements the critic.Messaging interface
+var _ critic.Messaging = (*DB)(nil)
 
 // GetConversations returns a list of conversation IDs
 // If status is provided, filters by that status (e.g., "unresolved")
@@ -25,7 +25,7 @@ func (db *DB) GetConversations(status string) ([]string, error) {
 			WHERE id = conversation_id
 			ORDER BY file_path, line_number, created_at ASC
 		`
-	} else if status == string(messaging.StatusUnresolved) {
+	} else if status == string(critic.StatusUnresolved) {
 		// Get unresolved conversations
 		query = `
 			SELECT id
@@ -34,7 +34,7 @@ func (db *DB) GetConversations(status string) ([]string, error) {
 			ORDER BY file_path, line_number, created_at ASC
 		`
 		args = []interface{}{string(StatusResolved)}
-	} else if status == string(messaging.StatusResolved) {
+	} else if status == string(critic.StatusResolved) {
 		// Get resolved conversations
 		query = `
 			SELECT id
@@ -68,7 +68,7 @@ func (db *DB) GetConversations(status string) ([]string, error) {
 
 // GetFullConversation returns the complete conversation including all replies
 // Messages are ordered by created_at (root message first, then replies in chronological order)
-func (db *DB) GetFullConversation(conversationID string) (*messaging.Conversation, error) {
+func (db *DB) GetFullConversation(conversationID string) (*critic.Conversation, error) {
 	// Get all messages in the conversation
 	messages, err := db.GetThreadMessages(conversationID)
 	if err != nil {
@@ -82,12 +82,12 @@ func (db *DB) GetFullConversation(conversationID string) (*messaging.Conversatio
 	// First message is the root
 	rootMsg := messages[0]
 
-	// Convert messages to messaging.Message type
-	criticMessages := make([]messaging.Message, len(messages))
+	// Convert messages to critic.Message type
+	criticMessages := make([]critic.Message, len(messages))
 	for i, msg := range messages {
-		criticMessages[i] = messaging.Message{
+		criticMessages[i] = critic.Message{
 			UUID:      msg.ID,
-			Author:    messaging.Author(msg.Author),
+			Author:    critic.Author(msg.Author),
 			Message:   msg.Message,
 			CreatedAt: msg.CreatedAt,
 			UpdatedAt: msg.UpdatedAt,
@@ -95,7 +95,7 @@ func (db *DB) GetFullConversation(conversationID string) (*messaging.Conversatio
 		}
 	}
 
-	conversation := &messaging.Conversation{
+	conversation := &critic.Conversation{
 		UUID:        rootMsg.ID,
 		Status:      convertToCriticStatus(rootMsg.Status),
 		FilePath:    rootMsg.FilePath,
@@ -110,8 +110,83 @@ func (db *DB) GetFullConversation(conversationID string) (*messaging.Conversatio
 	return conversation, nil
 }
 
+// GetConversationsForFile returns all conversations for a specific file
+func (db *DB) GetConversationsForFile(filePath string) ([]*critic.Conversation, error) {
+	// Get all root messages for this file
+	rootMessages, err := db.GetMessagesByFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get messages by file: %w", err)
+	}
+
+	// Build full conversations for each root message
+	conversations := make([]*critic.Conversation, 0, len(rootMessages))
+	for _, rootMsg := range rootMessages {
+		conv, err := db.GetFullConversation(rootMsg.ID)
+		if err != nil {
+			logger.Warn("Failed to get conversation %s: %v", rootMsg.ID, err)
+			continue
+		}
+		conversations = append(conversations, conv)
+	}
+
+	return conversations, nil
+}
+
+// GetFileConversationSummary returns a summary of conversations for a file
+func (db *DB) GetFileConversationSummary(filePath string) (*critic.FileConversationSummary, error) {
+	summary := &critic.FileConversationSummary{
+		FilePath: filePath,
+	}
+
+	// Query to check for unresolved, resolved, and unread conversations in one go
+	query := `
+		SELECT
+			CASE WHEN status != 'resolved' THEN 1 ELSE 0 END as is_unresolved,
+			CASE WHEN status = 'resolved' THEN 1 ELSE 0 END as is_resolved,
+			CASE WHEN author = 'ai' AND read_status = 'unread' THEN 1 ELSE 0 END as has_unread_ai
+		FROM messages
+		WHERE file_path = ? AND id = conversation_id
+	`
+
+	rows, err := db.db.Query(query, filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query file summary: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var isUnresolved, isResolved, hasUnreadAI int
+		if err := rows.Scan(&isUnresolved, &isResolved, &hasUnreadAI); err != nil {
+			return nil, fmt.Errorf("failed to scan file summary: %w", err)
+		}
+		if isUnresolved == 1 {
+			summary.HasUnresolvedComments = true
+		}
+		if isResolved == 1 {
+			summary.HasResolvedComments = true
+		}
+		if hasUnreadAI == 1 {
+			summary.HasUnreadAIMessages = true
+		}
+	}
+
+	// Also check for unread AI messages in replies (not just root messages)
+	if !summary.HasUnreadAIMessages {
+		unreadQuery := `
+			SELECT COUNT(*) FROM messages
+			WHERE file_path = ? AND author = 'ai' AND read_status = 'unread'
+		`
+		var count int
+		if err := db.db.QueryRow(unreadQuery, filePath).Scan(&count); err == nil && count > 0 {
+			summary.HasUnreadAIMessages = true
+		}
+	}
+
+	return summary, nil
+}
+
 // ReplyToConversation adds a reply to an existing conversation
-func (db *DB) ReplyToConversation(conversationID string, message string, author messaging.Author) (*messaging.Message, error) {
+func (db *DB) ReplyToConversation(conversationID string, message string, author critic.Author) (*critic.Message, error) {
 	// Verify conversation exists
 	rootMsg, err := db.GetMessage(conversationID)
 	if err != nil {
@@ -128,9 +203,9 @@ func (db *DB) ReplyToConversation(conversationID string, message string, author 
 		return nil, fmt.Errorf("failed to create reply: %w", err)
 	}
 
-	criticMsg := &messaging.Message{
+	criticMsg := &critic.Message{
 		UUID:      reply.ID,
-		Author:    messaging.Author(reply.Author),
+		Author:    critic.Author(reply.Author),
 		Message:   reply.Message,
 		CreatedAt: reply.CreatedAt,
 		UpdatedAt: reply.UpdatedAt,
@@ -142,23 +217,23 @@ func (db *DB) ReplyToConversation(conversationID string, message string, author 
 }
 
 // CreateConversation creates a new conversation (root message)
-func (db *DB) CreateConversation(author messaging.Author, message, filePath string, lineNumber int, codeVersion string) (*messaging.Conversation, error) {
+func (db *DB) CreateConversation(author critic.Author, message, filePath string, lineNumber int, codeVersion string) (*critic.Conversation, error) {
 	dbAuthor := Author(author)
 	rootMsg, err := db.CreateMessage(dbAuthor, message, filePath, lineNumber, codeVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create conversation: %w", err)
 	}
 
-	conversation := &messaging.Conversation{
+	conversation := &critic.Conversation{
 		UUID:        rootMsg.ID,
 		Status:      convertToCriticStatus(rootMsg.Status),
 		FilePath:    rootMsg.FilePath,
 		LineNumber:  rootMsg.LineNumber,
 		CodeVersion: rootMsg.CodeVersion,
-		Messages: []messaging.Message{
+		Messages: []critic.Message{
 			{
 				UUID:      rootMsg.ID,
-				Author:    messaging.Author(rootMsg.Author),
+				Author:    critic.Author(rootMsg.Author),
 				Message:   rootMsg.Message,
 				CreatedAt: rootMsg.CreatedAt,
 				UpdatedAt: rootMsg.UpdatedAt,
@@ -173,10 +248,10 @@ func (db *DB) CreateConversation(author messaging.Author, message, filePath stri
 	return conversation, nil
 }
 
-// convertToCriticStatus converts messagedb.Status to messaging.ConversationStatus
-func convertToCriticStatus(status Status) messaging.ConversationStatus {
+// convertToCriticStatus converts messagedb.Status to critic.ConversationStatus
+func convertToCriticStatus(status Status) critic.ConversationStatus {
 	if status == StatusResolved {
-		return messaging.StatusResolved
+		return critic.StatusResolved
 	}
-	return messaging.StatusUnresolved
+	return critic.StatusUnresolved
 }

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -6,11 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"git.15b.it/eno/critic/internal/comments"
-	"git.15b.it/eno/critic/pkg/messaging"
 	"git.15b.it/eno/critic/internal/git"
 	"git.15b.it/eno/critic/internal/highlight"
 	"git.15b.it/eno/critic/internal/logger"
+	"git.15b.it/eno/critic/pkg/critic"
 	ctypes "git.15b.it/eno/critic/pkg/types"
 	"github.com/alecthomas/chroma/v2"
 	"github.com/charmbracelet/bubbles/viewport"
@@ -33,12 +32,12 @@ type DiffViewModel struct {
 	cursorLine          int           // Current active line (0-based)
 	totalLines          int           // Total number of lines in rendered diff
 	focused             bool          // Whether this pane is focused
-	navigableLines      []int         // Line numbers that can have cursor (diff lines only)
-	commentManager      *comments.FileManager
-	messaging           messaging.Messaging // Messaging interface for conversations
-	commentLines        map[int]int      // Maps rendered line number to source line number for comment lines
-	sourceLines         map[int]int   // Maps rendered line number to source line number for all diff lines
-	preserveCursorLine  int           // Source line to restore cursor to after refresh (0 = don't preserve)
+	navigableLines           []int // Line numbers that can have cursor (diff lines only)
+	messaging                critic.Messaging
+	commentLines             map[int]int    // Maps rendered line number to source line number for comment lines
+	sourceLines              map[int]int    // Maps rendered line number to source line number for all diff lines
+	preserveCursorLine       int            // Source line to restore cursor to after refresh (0 = don't preserve)
+	lineConversationUUID     map[int]string // Maps rendered line number to conversation UUID
 }
 
 // NewDiffViewModel creates a new diff viewer model
@@ -494,14 +493,17 @@ func (m *DiffViewModel) SetHighlightingEnabled(enabled bool) {
 	m.cachedFile = nil
 }
 
-// SetCommentManager sets the comment manager for loading comments
-func (m *DiffViewModel) SetCommentManager(cm *comments.FileManager) {
-	m.commentManager = cm
+// SetMessaging sets the messaging interface for conversations
+func (m *DiffViewModel) SetMessaging(messaging critic.Messaging) {
+	m.messaging = messaging
 }
 
-// SetMessaging sets the messaging interface for conversations
-func (m *DiffViewModel) SetMessaging(messaging messaging.Messaging) {
-	m.messaging = messaging
+// GetConversationUUIDAtLine returns the conversation UUID for a rendered line
+func (m *DiffViewModel) GetConversationUUIDAtLine(renderedLine int) string {
+	if m.lineConversationUUID == nil {
+		return ""
+	}
+	return m.lineConversationUUID[renderedLine]
 }
 
 // IsCommentLine returns true if the given line number is a comment line
@@ -537,22 +539,29 @@ func (m *DiffViewModel) renderDiff() (string, int, []int) {
 	lineNum := 0             // Track current line number for cursor highlighting
 	var navigableLines []int // Track which lines can have cursor (diff lines only)
 
-	// Initialize comment and source line tracking
+	// Initialize comment, source line, and conversation tracking
 	m.commentLines = make(map[int]int)
 	m.sourceLines = make(map[int]int)
+	m.lineConversationUUID = make(map[int]string)
 
-	// Load comments for this file if comment manager is available
-	var fileComments *ctypes.CriticFile
-	if m.commentManager != nil {
+	// Load conversations for this file from messaging interface
+	var fileConversations []*critic.Conversation
+	if m.messaging != nil {
 		// Get the git-relative path
 		gitPath := m.file.NewPath
 		if m.file.IsDeleted {
 			gitPath = m.file.OldPath
 		}
-		// Try to load comments
-		if loaded, err := m.commentManager.LoadComments(gitPath); err == nil {
-			fileComments = loaded
+		// Try to load conversations
+		if convs, err := m.messaging.GetConversationsForFile(gitPath); err == nil {
+			fileConversations = convs
 		}
+	}
+
+	// Build a map of line number to conversation for quick lookup
+	conversationsByLine := make(map[int]*critic.Conversation)
+	for _, conv := range fileConversations {
+		conversationsByLine[conv.LineNumber] = conv
 	}
 
 	filename := git.GitPathToDisplayPath(m.file.NewPath)
@@ -645,15 +654,16 @@ func (m *DiffViewModel) renderDiff() (string, int, []int) {
 			lineNum++
 			b.WriteString("\n")
 
-			// Check if there's a comment for this line
-			if fileComments != nil && line.NewNum > 0 {
-				if comment, exists := fileComments.Comments[line.NewNum]; exists && len(comment.Lines) > 0 {
-					// Render up to 6 lines of the comment preview (plus indicator if needed)
-					commentLines := m.renderCommentPreview(comment, lineNum)
+			// Check if there's a conversation for this line
+			if line.NewNum > 0 {
+				if conv, exists := conversationsByLine[line.NewNum]; exists {
+					// Render conversation preview
+					commentLines := m.renderConversationPreview(conv, lineNum)
 					for _, commentLine := range commentLines {
 						b.WriteString(commentLine)
-						// Track all comment lines (including indicator) for navigation
+						// Track all comment lines for navigation
 						m.commentLines[lineNum] = line.NewNum
+						m.lineConversationUUID[lineNum] = conv.UUID
 						// Add to navigable lines so user can select it
 						navigableLines = append(navigableLines, lineNum)
 						lineNum++
@@ -804,53 +814,45 @@ func (m *DiffViewModel) highlightFromHunks(file *ctypes.FileDiff, filename strin
 	return result
 }
 
-// renderCommentPreview renders up to 6 lines of a comment preview with dark text on black background
-// Each line starts with a half-width block character in yellow/gold color
-// If the comment has a UUID, it loads the thread from the database and displays replies
-func (m *DiffViewModel) renderCommentPreview(comment *ctypes.CriticBlock, startLineNum int) []string {
-	// Build the complete comment text including replies from the database
+// renderConversationPreview renders a conversation preview with all messages
+func (m *DiffViewModel) renderConversationPreview(conv *critic.Conversation, startLineNum int) []string {
+	// Build the complete text including all messages
 	var allLines []string
 
-	// Start with the original comment lines
-	allLines = append(allLines, comment.Lines...)
+	for i, msg := range conv.Messages {
+		prefix := "human>"
+		if msg.Author == critic.AuthorAI {
+			prefix = "ai>"
 
-	// If we have a UUID and messaging, load the conversation
-	if comment.UUID != "" && m.messaging != nil {
-		conversation, err := m.messaging.GetFullConversation(comment.UUID)
-		if err != nil {
-			logger.Warn("Failed to load conversation for UUID %s: %v", comment.UUID, err)
-		} else if len(conversation.Messages) > 1 {
-			// First message is the root (already displayed), so start from index 1
-			for i := 1; i < len(conversation.Messages); i++ {
-				msg := conversation.Messages[i]
-				prefix := "human>"
-				if msg.Author == messaging.AuthorAI {
-					prefix = "ai>"
-
-					// Mark AI messages as read when they're displayed
-					if msg.IsUnread {
-						if err := m.messaging.MarkAsRead(msg.UUID); err != nil {
-							logger.Warn("Failed to mark AI message as read: %v", err)
-						} else {
-							logger.Debug("Marked AI message %s as read", msg.UUID)
-						}
-					}
-				}
-				// Add each line of the reply with the prefix
-				replyLines := strings.Split(msg.Message, "\n")
-				for _, line := range replyLines {
-					allLines = append(allLines, prefix+" "+line)
+			// Mark AI messages as read when they're displayed
+			if msg.IsUnread && m.messaging != nil {
+				if err := m.messaging.MarkAsRead(msg.UUID); err != nil {
+					logger.Warn("Failed to mark AI message as read: %v", err)
+				} else {
+					logger.Debug("Marked AI message %s as read", msg.UUID)
 				}
 			}
+		}
 
-			// Check if the conversation is resolved
-			if conversation.Status == messaging.StatusResolved {
-				// Prepend "(Resolved)" to the first line
-				if len(allLines) > 0 {
-					// Use italic if possible (ANSI escape: \x1b[3m for italic, \x1b[23m to disable)
-					allLines[0] = "\x1b[3m(Resolved)\x1b[23m " + allLines[0]
-				}
+		// First message doesn't need prefix if it's human
+		if i == 0 && msg.Author == critic.AuthorHuman {
+			// Add each line of the root message
+			msgLines := strings.Split(msg.Message, "\n")
+			allLines = append(allLines, msgLines...)
+		} else {
+			// Add each line of the reply with the prefix
+			replyLines := strings.Split(msg.Message, "\n")
+			for _, line := range replyLines {
+				allLines = append(allLines, prefix+" "+line)
 			}
+		}
+	}
+
+	// Check if the conversation is resolved
+	if conv.Status == critic.StatusResolved {
+		// Prepend "(Resolved)" to the first line
+		if len(allLines) > 0 {
+			allLines[0] = "\x1b[3m(Resolved)\x1b[23m " + allLines[0]
 		}
 	}
 
@@ -1123,34 +1125,21 @@ func min(a, b int) int {
 // resolveCommentAtCursor resolves the comment at the current cursor position
 func (m *DiffViewModel) resolveCommentAtCursor() tea.Cmd {
 	// Check if cursor is on a comment line
-	if isComment, sourceLine := m.IsCommentLine(m.cursorLine); isComment {
-		// Load the comments for this file
-		if m.file != nil && m.commentManager != nil && m.messaging != nil {
-			filePath := m.file.NewPath
-			if filePath == "" {
-				filePath = m.file.OldPath
-			}
-
-			criticFile, err := m.commentManager.LoadComments(filePath)
+	if isComment, _ := m.IsCommentLine(m.cursorLine); isComment {
+		// Get conversation UUID for this line
+		uuid := m.GetConversationUUIDAtLine(m.cursorLine)
+		if uuid != "" && m.messaging != nil {
+			// Mark as resolved in the database
+			err := m.messaging.MarkAsResolved(uuid)
 			if err != nil {
-				logger.Error("Failed to load comments for resolve: %v", err)
+				logger.Error("Failed to mark conversation as resolved: %v", err)
 				return nil
 			}
 
-			// Find the comment block for this source line
-			if comment, exists := criticFile.Comments[sourceLine]; exists && comment.UUID != "" {
-				// Mark as resolved in the database
-				err := m.messaging.MarkAsResolved(comment.UUID)
-				if err != nil {
-					logger.Error("Failed to mark conversation as resolved: %v", err)
-					return nil
-				}
+			logger.Info("Marked comment %s as resolved", uuid)
 
-				logger.Info("Marked comment %s as resolved", comment.UUID)
-
-				// Refresh the view to show the "(Resolved)" indicator
-				return m.RefreshFile()
-			}
+			// Refresh the view to show the "(Resolved)" indicator
+			return m.RefreshFile()
 		}
 	}
 

--- a/internal/ui/filelist.go
+++ b/internal/ui/filelist.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"git.15b.it/eno/critic/internal/comments"
-	"git.15b.it/eno/critic/pkg/messaging"
 	"git.15b.it/eno/critic/internal/git"
+	"git.15b.it/eno/critic/pkg/critic"
 	ctypes "git.15b.it/eno/critic/pkg/types"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -15,16 +14,15 @@ import (
 
 // FileListModel represents the file list pane
 type FileListModel struct {
-	files          []*ctypes.FileDiff
-	cursor         int
-	viewport       viewport.Model
-	width          int
-	height         int
-	ready          bool
-	activeFile     *ctypes.FileDiff
-	focused        bool
-	commentManager *comments.FileManager
-	messaging      messaging.Messaging
+	files      []*ctypes.FileDiff
+	cursor     int
+	viewport   viewport.Model
+	width      int
+	height     int
+	ready      bool
+	activeFile *ctypes.FileDiff
+	focused    bool
+	messaging  critic.Messaging
 }
 
 // NewFileListModel creates a new file list model
@@ -92,28 +90,23 @@ func (m FileListModel) View() string {
 	for i, file := range m.files {
 		style := normalFileStyle
 
-		// Check if file has comments
-		hasComments := false
-		hasUnreadAI := false
-		if m.commentManager != nil {
-			// Use the git-relative path for checking comments
-			gitPath := file.NewPath
-			if file.IsDeleted {
-				gitPath = file.OldPath
-			}
-			hasComments = m.commentManager.HasComments(gitPath)
+		// Get the git-relative path for checking conversations
+		gitPath := file.NewPath
+		if file.IsDeleted {
+			gitPath = file.OldPath
+		}
 
-			// Check for unread AI comments
-			if m.messaging != nil {
-				unreadFiles, err := m.messaging.GetFilesWithUnreadAIMessages()
-				if err == nil {
-					for _, unreadPath := range unreadFiles {
-						if unreadPath == gitPath {
-							hasUnreadAI = true
-							break
-						}
-					}
-				}
+		// Get conversation summary from messaging interface
+		var hasUnreadAI bool
+		var hasUnresolved bool
+		var hasResolved bool
+
+		if m.messaging != nil {
+			summary, err := m.messaging.GetFileConversationSummary(gitPath)
+			if err == nil && summary != nil {
+				hasUnreadAI = summary.HasUnreadAIMessages
+				hasUnresolved = summary.HasUnresolvedComments
+				hasResolved = summary.HasResolvedComments
 			}
 		}
 
@@ -147,17 +140,22 @@ func (m FileListModel) View() string {
 
 		// Add left indicator:
 		// - Red/bright block for files with unread AI comments
-		// - Yellow half-block for files with comments
+		// - Yellow block for files with unresolved comments
+		// - Green block for files with only resolved comments
 		// - Space for files without comments
 		var leftIndicator string
 		if hasUnreadAI {
-			// Red block for unread AI comments (more attention-grabbing)
+			// Red block for unread AI comments (most attention-grabbing)
 			const redBlock = "\x1b[38;5;196m▌\x1b[0m"
 			leftIndicator = redBlock
-		} else if hasComments {
-			// Yellow block for regular comments
+		} else if hasUnresolved {
+			// Yellow block for unresolved comments
 			const yellowBlock = "\x1b[38;5;220m▌\x1b[0m"
 			leftIndicator = yellowBlock
+		} else if hasResolved {
+			// Green block for resolved comments
+			const greenBlock = "\x1b[38;5;34m▌\x1b[0m"
+			leftIndicator = greenBlock
 		} else {
 			leftIndicator = " "
 		}
@@ -260,12 +258,7 @@ func (m *FileListModel) SetFocused(focused bool) {
 	m.focused = focused
 }
 
-// SetCommentManager sets the comment manager for checking file comments
-func (m *FileListModel) SetCommentManager(cm *comments.FileManager) {
-	m.commentManager = cm
-}
-
-// SetMessaging sets the messaging interface for checking unread AI messages
-func (m *FileListModel) SetMessaging(messaging messaging.Messaging) {
+// SetMessaging sets the messaging interface for checking conversation status
+func (m *FileListModel) SetMessaging(messaging critic.Messaging) {
 	m.messaging = messaging
 }

--- a/pkg/critic/messaging.go
+++ b/pkg/critic/messaging.go
@@ -1,4 +1,4 @@
-package messaging
+package critic
 
 import "time"
 
@@ -40,6 +40,14 @@ type Conversation struct {
 	UpdatedAt   time.Time
 }
 
+// FileConversationSummary contains information about conversations for a specific file
+type FileConversationSummary struct {
+	FilePath              string
+	HasUnresolvedComments bool
+	HasResolvedComments   bool
+	HasUnreadAIMessages   bool
+}
+
 // Messaging defines the interface for managing critic conversations
 type Messaging interface {
 	// GetConversations returns a list of conversation UUIDs
@@ -50,6 +58,13 @@ type Messaging interface {
 	// GetFullConversation returns the complete conversation including all replies
 	// Messages are ordered by created_at (root message first, then replies in chronological order)
 	GetFullConversation(uuid string) (*Conversation, error)
+
+	// GetConversationsForFile returns all conversations for a specific file
+	GetConversationsForFile(filePath string) ([]*Conversation, error)
+
+	// GetFileConversationSummary returns a summary of conversations for a file
+	// This is used for efficient file list rendering
+	GetFileConversationSummary(filePath string) (*FileConversationSummary, error)
 
 	// ReplyToConversation adds a reply to an existing conversation
 	ReplyToConversation(conversationUUID string, message string, author Author) (*Message, error)


### PR DESCRIPTION
…comments and current mode

- Move Messaging interface and types from pkg/messaging to pkg/critic
- Add GetConversationsForFile and GetFileConversationSummary methods
- Update file list to load conversations from messaging interface per file
- Show resolved/unresolved/unread indicators based on conversation status
- Remove .critic/ file-based comment storage (comments.FileManager)
- Load and display conversations directly from SQLite database
- Remove 'current' feature (working directory diffing with file watcher)
- Always diff against HEAD instead of working directory
- Simplify CLI parser to only accept base refs, not base..current syntax
- Update all imports to use pkg/critic instead of pkg/messaging