### PR TITLE
Add filter hotkey with multiple modes

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,14 +8,38 @@ import (
 
 	"git.15b.it/eno/critic/internal/config"
 	"git.15b.it/eno/critic/internal/git"
-	"git.15b.it/eno/critic/simple-go/logger"
 	"git.15b.it/eno/critic/internal/messagedb"
 	"git.15b.it/eno/critic/internal/ui"
 	"git.15b.it/eno/critic/pkg/critic"
 	ctypes "git.15b.it/eno/critic/pkg/types"
+	"git.15b.it/eno/critic/simple-go/logger"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
+
+// FilterMode represents the current file/hunk filter mode
+type FilterMode int
+
+const (
+	// FilterModeNone shows all files and hunks (default)
+	FilterModeNone FilterMode = iota
+	// FilterModeWithComments shows only files with comments, and only hunks with comments
+	FilterModeWithComments
+	// FilterModeWithUnresolved shows only files with unresolved comments, and only hunks with unresolved comments
+	FilterModeWithUnresolved
+)
+
+// String returns a display name for the filter mode
+func (m FilterMode) String() string {
+	switch m {
+	case FilterModeWithComments:
+		return "With Comments"
+	case FilterModeWithUnresolved:
+		return "Unresolved Only"
+	default:
+		return "All"
+	}
+}
 
 // Args represents parsed command-line arguments
 type Args struct {
@@ -105,6 +129,7 @@ type Model struct {
 	extensions    []string          // File extensions to include
 	resolver      *git.BaseResolver // Base resolver with polling
 	messaging     critic.Messaging  // Messaging interface for conversations
+	filterMode    FilterMode        // Current filter mode (None, WithComments, WithUnresolved)
 	err           error
 	width         int
 	height        int
@@ -190,6 +215,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.currentBase = (m.currentBase + 1) % len(m.bases)
 			logger.Info("Update: Switching to base %d: %s", m.currentBase, m.bases[m.currentBase])
 			return m, loadDiffCmd(&m)
+
+		case "F":
+			// Cycle through filter modes
+			m.filterMode = (m.filterMode + 1) % 3
+			logger.Info("Update: Switching to filter mode %d: %s", m.filterMode, m.filterMode.String())
+			// Re-apply filter to file list and update diff view
+			m.applyFilterMode()
+			cmd := m.diffView.SetFile(m.fileList.GetActiveFile())
+			cmds = append(cmds, cmd)
+			return m, tea.Batch(cmds...)
 
 		case " ": // Space - page down diff view regardless of focus
 			// Scroll by height - 3 (but at least 1 row) and position cursor on second line
@@ -297,23 +332,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.err = msg.err
 		if m.diff != nil {
 			logger.Info("Update: Diff loaded with %d files", len(m.diff.Files))
-			// Remember currently selected file path
-			var currentPath string
-			if activeFile := m.fileList.GetActiveFile(); activeFile != nil {
-				currentPath = activeFile.NewPath
-				if currentPath == "" {
-					currentPath = activeFile.OldPath
-				}
-			}
 
-			// Update file list with new diff
-			m.fileList.SetFiles(m.diff.Files)
-
-			// Try to restore selection to the same file
-			if currentPath != "" {
-				logger.Info("Update: Restoring selection to %s", currentPath)
-				m.fileList.SelectByPath(currentPath)
-			}
+			// Apply filter mode (this handles file selection and filtering)
+			m.applyFilterMode()
 
 			// Update diff view with (potentially) new content
 			cmd := m.diffView.SetFile(m.fileList.GetActiveFile())
@@ -398,7 +419,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmd := m.diffView.RefreshFile()
 			cmds = append(cmds, cmd)
 		}
-
 
 	default:
 		// Route other messages to diff view (like diffRenderedMsg)
@@ -486,9 +506,17 @@ func (m Model) renderStatusBar() string {
 		parts = append(parts, fmt.Sprintf("[B]ase: %s → HEAD", base))
 	}
 
-	// Show file count
+	// Show filter mode
+	parts = append(parts, fmt.Sprintf("[F]ilter: %s", m.filterMode.String()))
+
+	// Show file count (filtered count if filtering)
 	if m.diff != nil {
-		parts = append(parts, fmt.Sprintf("Files: %d", len(m.diff.Files)))
+		filteredFiles := m.filterFiles(m.diff.Files)
+		if m.filterMode == FilterModeNone {
+			parts = append(parts, fmt.Sprintf("Files: %d", len(m.diff.Files)))
+		} else {
+			parts = append(parts, fmt.Sprintf("Files: %d/%d", len(filteredFiles), len(m.diff.Files)))
+		}
 	}
 
 	// Show help hint
@@ -687,6 +715,9 @@ func (m Model) renderHelpOverlay(underlay string) string {
   BASE SWITCHING
     b/B           Switch to next/previous base
 
+  FILTERING
+    F             Cycle filter mode (All → With Comments → Unresolved Only)
+
   OTHER
     r             Reload diff
     ?             Toggle this help screen
@@ -725,6 +756,72 @@ func (m Model) renderHelpOverlay(underlay string) string {
 
 	// Overlay on the main view
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, positioned)
+}
+
+// applyFilterMode filters the file list based on the current filter mode
+func (m *Model) applyFilterMode() {
+	if m.diff == nil {
+		return
+	}
+
+	// Filter files based on the current mode
+	filteredFiles := m.filterFiles(m.diff.Files)
+
+	// Remember currently selected file path
+	var currentPath string
+	if activeFile := m.fileList.GetActiveFile(); activeFile != nil {
+		currentPath = activeFile.NewPath
+		if currentPath == "" {
+			currentPath = activeFile.OldPath
+		}
+	}
+
+	// Update file list with filtered files
+	m.fileList.SetFiles(filteredFiles)
+
+	// Try to restore selection to the same file
+	if currentPath != "" {
+		m.fileList.SelectByPath(currentPath)
+	}
+
+	// Update the diff view's filter mode
+	m.diffView.SetFilterMode(ui.FilterMode(m.filterMode))
+}
+
+// filterFiles returns files that match the current filter mode
+func (m *Model) filterFiles(files []*ctypes.FileDiff) []*ctypes.FileDiff {
+	if m.filterMode == FilterModeNone {
+		return files
+	}
+
+	var filtered []*ctypes.FileDiff
+	for _, file := range files {
+		gitPath := file.NewPath
+		if file.IsDeleted {
+			gitPath = file.OldPath
+		}
+
+		// Get conversation summary for this file
+		summary, err := m.messaging.GetFileConversationSummary(gitPath)
+		if err != nil {
+			continue
+		}
+
+		switch m.filterMode {
+		case FilterModeWithComments:
+			// Include if file has any comments (resolved or unresolved)
+			if summary.HasUnresolvedComments || summary.HasResolvedComments {
+				filtered = append(filtered, file)
+			}
+		case FilterModeWithUnresolved:
+			// Include only if file has unresolved comments
+			if summary.HasUnresolvedComments {
+				filtered = append(filtered, file)
+			}
+		}
+	}
+
+	return filtered
 }
 
 // getCurrentCodeVersion returns the current git commit hash as the code version

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -9,37 +9,50 @@ import (
 	"git.15b.it/eno/critic/internal/config"
 	"git.15b.it/eno/critic/internal/git"
 	"git.15b.it/eno/critic/internal/highlight"
-	"git.15b.it/eno/critic/simple-go/logger"
 	"git.15b.it/eno/critic/pkg/critic"
 	ctypes "git.15b.it/eno/critic/pkg/types"
+	"git.15b.it/eno/critic/simple-go/logger"
 	"github.com/alecthomas/chroma/v2"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
 
+// FilterMode represents the current file/hunk filter mode
+type FilterMode int
+
+const (
+	// FilterModeNone shows all files and hunks (default)
+	FilterModeNone FilterMode = iota
+	// FilterModeWithComments shows only files with comments, and only hunks with comments
+	FilterModeWithComments
+	// FilterModeWithUnresolved shows only files with unresolved comments, and only hunks with unresolved comments
+	FilterModeWithUnresolved
+)
+
 // DiffViewModel represents the diff viewer pane
 type DiffViewModel struct {
-	file                *ctypes.FileDiff
-	viewport            viewport.Model
-	width               int
-	height              int
-	ready               bool
-	highlighter         *highlight.Highlighter
-	cachedContent       string
-	cachedFile          *ctypes.FileDiff
-	highlightingEnabled bool
-	highlightTime       time.Duration // Accumulated syntax highlighting time
-	cursorLine          int           // Current active line (0-based)
-	totalLines          int           // Total number of lines in rendered diff
-	focused              bool                // Whether this pane is focused
-	navigableLines       []int               // Line numbers that can have cursor (diff lines only)
+	file                 *ctypes.FileDiff
+	viewport             viewport.Model
+	width                int
+	height               int
+	ready                bool
+	highlighter          *highlight.Highlighter
+	cachedContent        string
+	cachedFile           *ctypes.FileDiff
+	highlightingEnabled  bool
+	highlightTime        time.Duration // Accumulated syntax highlighting time
+	cursorLine           int           // Current active line (0-based)
+	totalLines           int           // Total number of lines in rendered diff
+	focused              bool          // Whether this pane is focused
+	navigableLines       []int         // Line numbers that can have cursor (diff lines only)
 	messaging            critic.Messaging
-	commentLines         map[int]int         // Maps rendered line number to source line number for comment lines
-	sourceLines          map[int]int         // Maps rendered line number to source line number for all diff lines
-	preserveCursorLine   int                 // Source line to restore cursor to after refresh (0 = don't preserve)
-	lineConversationUUID map[int]string      // Maps rendered line number to conversation UUID
-	gotoBottomOnLoad     bool                // If true, go to bottom after next file load
+	commentLines         map[int]int    // Maps rendered line number to source line number for comment lines
+	sourceLines          map[int]int    // Maps rendered line number to source line number for all diff lines
+	preserveCursorLine   int            // Source line to restore cursor to after refresh (0 = don't preserve)
+	lineConversationUUID map[int]string // Maps rendered line number to conversation UUID
+	gotoBottomOnLoad     bool           // If true, go to bottom after next file load
+	filterMode           FilterMode     // Current filter mode for hunk filtering
 }
 
 // NewDiffViewModel creates a new diff viewer model
@@ -662,6 +675,53 @@ func (m *DiffViewModel) SetMessaging(messaging critic.Messaging) {
 	m.messaging = messaging
 }
 
+// SetFilterMode sets the filter mode for hunk filtering
+func (m *DiffViewModel) SetFilterMode(mode FilterMode) {
+	if m.filterMode != mode {
+		m.filterMode = mode
+		// Clear cache to force re-render with new filter
+		m.cachedFile = nil
+	}
+}
+
+// filterHunks filters hunks based on the current filter mode
+func (m *DiffViewModel) filterHunks(hunks []*ctypes.Hunk, conversationsByLine map[int]*critic.Conversation) []*ctypes.Hunk {
+	// If no filter, return all hunks
+	if m.filterMode == FilterModeNone {
+		return hunks
+	}
+
+	var filtered []*ctypes.Hunk
+	for _, hunk := range hunks {
+		if m.hunkMatchesFilter(hunk, conversationsByLine) {
+			filtered = append(filtered, hunk)
+		}
+	}
+
+	return filtered
+}
+
+// hunkMatchesFilter checks if a hunk should be included based on the current filter mode
+func (m *DiffViewModel) hunkMatchesFilter(hunk *ctypes.Hunk, conversationsByLine map[int]*critic.Conversation) bool {
+	for _, line := range hunk.Lines {
+		if line.NewNum > 0 {
+			if conv, exists := conversationsByLine[line.NewNum]; exists {
+				switch m.filterMode {
+				case FilterModeWithComments:
+					// Any comment matches
+					return true
+				case FilterModeWithUnresolved:
+					// Only unresolved comments match
+					if conv.Status != critic.StatusResolved {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
 // GetConversationUUIDAtLine returns the conversation UUID for a rendered line
 func (m *DiffViewModel) GetConversationUUIDAtLine(renderedLine int) string {
 	if m.lineConversationUUID == nil {
@@ -753,9 +813,9 @@ func (m *DiffViewModel) renderDiff() (string, int, []int) {
 	b.WriteString("\n")
 
 	// Highlight files with appropriate background styles
-	var oldFileDeleted map[int]string  // old file with deleted background
-	var newFileAdded map[int]string    // new file with added background
-	var newFileContext map[int]string  // new file with context background
+	var oldFileDeleted map[int]string // old file with deleted background
+	var newFileAdded map[int]string   // new file with added background
+	var newFileContext map[int]string // new file with context background
 
 	if m.highlightingEnabled {
 		hlStart := time.Now()
@@ -765,8 +825,11 @@ func (m *DiffViewModel) renderDiff() (string, int, []int) {
 		m.highlightTime += time.Since(hlStart)
 	}
 
+	// Filter hunks based on filter mode
+	hunksToRender := m.filterHunks(m.file.Hunks, conversationsByLine)
+
 	// Render each hunk
-	for hunkIdx, hunk := range m.file.Hunks {
+	for hunkIdx, hunk := range hunksToRender {
 		// Render hunk header
 		hunkHeader := fmt.Sprintf("@@ -%d,%d +%d,%d @@", hunk.OldStart, hunk.OldLines, hunk.NewStart, hunk.NewLines)
 		if hunk.Header != "" {
@@ -838,7 +901,7 @@ func (m *DiffViewModel) renderDiff() (string, int, []int) {
 		}
 
 		// Add spacing between hunks
-		if hunkIdx < len(m.file.Hunks)-1 {
+		if hunkIdx < len(hunksToRender)-1 {
 			b.WriteString(m.renderLineWithCursor(m.truncateToWidth(""), lineNum))
 			lineNum++
 			b.WriteString("\n")
@@ -1223,7 +1286,7 @@ func (m *DiffViewModel) truncateToWidth(line string) string {
 		// Pad to full width - need to preserve the last background color for padding
 		// Extract the last background color from the line (if any)
 		lastBg := extractLastBackground(line)
-		padding := strings.Repeat(" ", m.width - visibleWidth)
+		padding := strings.Repeat(" ", m.width-visibleWidth)
 		if lastBg != "" {
 			// Apply the background color to padding spaces
 			return line + lastBg + padding + "\x1b[0m"
@@ -1258,7 +1321,7 @@ func (m *DiffViewModel) ensureFullLineBackground(line string, lineType ctypes.Li
 
 	padding := ""
 	if visibleWidth < m.width {
-		padding = strings.Repeat(" ", m.width - visibleWidth)
+		padding = strings.Repeat(" ", m.width-visibleWidth)
 	}
 
 	// Wrap entire line with background: bg + content + padding + reset


### PR DESCRIPTION
Implement three filter modes accessible via the 'F' hotkey:
- Mode 0 (All): Show all files and hunks (default)
- Mode 1 (With Comments): Show only files/hunks with comments
- Mode 2 (Unresolved Only): Show only files/hunks with unresolved comments

The status bar displays the current filter mode and filtered/total file counts. Help screen updated with new FILTERING section.