### PR TITLE
Fix filter mode hotkey and status display

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -216,8 +216,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			logger.Info("Update: Switching to base %d: %s", m.currentBase, m.bases[m.currentBase])
 			return m, loadDiffCmd(&m)
 
-		case "F":
-			// Cycle through filter modes
+		case "f", "F":
+			// Cycle through filter modes (works from both file list and diff pane)
 			m.filterMode = (m.filterMode + 1) % 3
 			logger.Info("Update: Switching to filter mode %d: %s", m.filterMode, m.filterMode.String())
 			// Re-apply filter to file list and update diff view
@@ -506,8 +506,8 @@ func (m Model) renderStatusBar() string {
 		parts = append(parts, fmt.Sprintf("[B]ase: %s → HEAD", base))
 	}
 
-	// Show filter mode
-	parts = append(parts, fmt.Sprintf("[F]ilter: %s", m.filterMode.String()))
+	// Show filter mode (always visible in status bar)
+	parts = append(parts, fmt.Sprintf("[f]ilter: %s", m.filterMode.String()))
 
 	// Show file count (filtered count if filtering)
 	if m.diff != nil {
@@ -716,7 +716,7 @@ func (m Model) renderHelpOverlay(underlay string) string {
     b/B           Switch to next/previous base
 
   FILTERING
-    F             Cycle filter mode (All → With Comments → Unresolved Only)
+    f/F           Cycle filter mode (All → With Comments → Unresolved Only)
 
   OTHER
     r             Reload diff
@@ -776,8 +776,9 @@ func (m *Model) applyFilterMode() {
 		}
 	}
 
-	// Update file list with filtered files
+	// Update file list with filtered files and set filter mode info
 	m.fileList.SetFiles(filteredFiles)
+	m.fileList.SetFilterMode(int(m.filterMode), len(m.diff.Files))
 
 	// Try to restore selection to the same file
 	if currentPath != "" {
@@ -786,6 +787,9 @@ func (m *Model) applyFilterMode() {
 
 	// Update the diff view's filter mode
 	m.diffView.SetFilterMode(ui.FilterMode(m.filterMode))
+
+	logger.Info("applyFilterMode: mode=%s, filtered=%d/%d files",
+		m.filterMode.String(), len(filteredFiles), len(m.diff.Files))
 }
 
 // filterFiles returns files that match the current filter mode
@@ -804,6 +808,7 @@ func (m *Model) filterFiles(files []*ctypes.FileDiff) []*ctypes.FileDiff {
 		// Get conversation summary for this file
 		summary, err := m.messaging.GetFileConversationSummary(gitPath)
 		if err != nil {
+			logger.Warn("filterFiles: error getting summary for %s: %v", gitPath, err)
 			continue
 		}
 
@@ -812,14 +817,19 @@ func (m *Model) filterFiles(files []*ctypes.FileDiff) []*ctypes.FileDiff {
 			// Include if file has any comments (resolved or unresolved)
 			if summary.HasUnresolvedComments || summary.HasResolvedComments {
 				filtered = append(filtered, file)
+				logger.Debug("filterFiles: including %s (has comments)", gitPath)
 			}
 		case FilterModeWithUnresolved:
 			// Include only if file has unresolved comments
 			if summary.HasUnresolvedComments {
 				filtered = append(filtered, file)
+				logger.Debug("filterFiles: including %s (has unresolved)", gitPath)
 			}
 		}
 	}
+
+	logger.Info("filterFiles: mode=%s, files=%d->%d",
+		m.filterMode.String(), len(files), len(filtered))
 
 	return filtered
 }

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -698,6 +698,9 @@ func (m *DiffViewModel) filterHunks(hunks []*ctypes.Hunk, conversationsByLine ma
 		}
 	}
 
+	logger.Info("filterHunks: mode=%d, hunks=%d->%d, conversations=%d",
+		m.filterMode, len(hunks), len(filtered), len(conversationsByLine))
+
 	return filtered
 }
 
@@ -827,6 +830,14 @@ func (m *DiffViewModel) renderDiff() (string, int, []int) {
 
 	// Filter hunks based on filter mode
 	hunksToRender := m.filterHunks(m.file.Hunks, conversationsByLine)
+
+	// Show message if all hunks were filtered out
+	if len(hunksToRender) == 0 && len(m.file.Hunks) > 0 && m.filterMode != FilterModeNone {
+		msg := "No hunks match filter (press f to show all)"
+		b.WriteString(m.renderLineWithCursor(m.truncateToWidth(hunkHeaderStyle.Render(msg)), lineNum))
+		lineNum++
+		b.WriteString("\n")
+	}
 
 	// Render each hunk
 	for hunkIdx, hunk := range hunksToRender {

--- a/internal/ui/filelist_widget.go
+++ b/internal/ui/filelist_widget.go
@@ -27,10 +27,12 @@ func (f FileItem) FilterValue() string {
 // FileListWidget is a teapot-based file list widget
 type FileListWidget struct {
 	pot.BaseWidget
-	list      *pot.SelectableList[FileItem]
-	messaging critic.Messaging
-	width     int
-	height    int
+	list       *pot.SelectableList[FileItem]
+	messaging  critic.Messaging
+	width      int
+	height     int
+	filterMode int // 0 = all, 1 = with comments, 2 = unresolved only
+	totalFiles int // Total files before filtering (for "No files match filter" message)
 }
 
 // NewFileListWidget creates a new file list widget
@@ -208,6 +210,13 @@ func (w *FileListWidget) SetMessaging(messaging critic.Messaging) {
 	w.messaging = messaging
 }
 
+// SetFilterMode sets the current filter mode and total files count
+// filterMode: 0 = all, 1 = with comments, 2 = unresolved only
+func (w *FileListWidget) SetFilterMode(filterMode int, totalFiles int) {
+	w.filterMode = filterMode
+	w.totalFiles = totalFiles
+}
+
 // SetBounds implements pot.Widget
 func (w *FileListWidget) SetBounds(bounds pot.Rect) {
 	w.BaseWidget.SetBounds(bounds)
@@ -227,7 +236,15 @@ func (w *FileListWidget) Render(buf *pot.SubBuffer) {
 	if len(w.list.Items()) == 0 {
 		style := lipgloss.NewStyle().
 			Foreground(lipgloss.AdaptiveColor{Light: "#999", Dark: "#666"})
-		buf.SetString(1, 1, "No files changed", style)
+		// Show appropriate message based on filter mode
+		var msg string
+		if w.filterMode > 0 && w.totalFiles > 0 {
+			// Files exist but none match the current filter
+			msg = "No files match filter (press f to show all)"
+		} else {
+			msg = "No files changed"
+		}
+		buf.SetString(1, 1, msg, style)
 		return
 	}
 	w.list.Render(buf)


### PR DESCRIPTION
- Make filter hotkey work with both lowercase 'f' and uppercase 'F'
- Update help screen and status bar to reflect lowercase 'f'
- Add filter mode tracking to file list widget to show proper message when all files are filtered out ("No files match filter")
- Add message in diff view when all hunks are filtered out
- Add debug/info logging to help diagnose filtering issues
- Both messages include "(press f to show all)" hint

Fixes issues where:
- Filter hotkey might not work from both panes
- Users weren't clear on why files/hunks disappeared when filtering