### PR TITLE
Mark conversations as read by AI

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -118,23 +118,25 @@ func Run(args *Args) error {
 
 // Model represents the main application model
 type Model struct {
-	fileList      *ui.FileListWidget
-	diffView      ui.DiffViewModel
-	commentEditor ui.CommentEditor
-	layout        ui.LayoutModel
-	diff          *ctypes.Diff
-	bases         []string          // List of base refs
-	currentBase   int               // Index of current base
-	paths         []string          // Paths to diff
-	extensions    []string          // File extensions to include
-	resolver      *git.BaseResolver // Base resolver with polling
-	messaging     critic.Messaging  // Messaging interface for conversations
-	filterMode    FilterMode        // Current filter mode (None, WithComments, WithUnresolved)
-	err           error
-	width         int
-	height        int
-	ready         bool
-	showHelp      bool // Whether to show help screen
+	fileList        *ui.FileListWidget
+	diffView        ui.DiffViewModel
+	commentEditor   ui.CommentEditor
+	layout          ui.LayoutModel
+	diff            *ctypes.Diff
+	bases           []string          // List of base refs
+	currentBase     int               // Index of current base
+	paths           []string          // Paths to diff
+	extensions      []string          // File extensions to include
+	resolver        *git.BaseResolver // Base resolver with polling
+	messaging       critic.Messaging  // Messaging interface for conversations
+	filterMode      FilterMode        // Current filter mode (None, WithComments, WithUnresolved)
+	animationTicker *ui.AnimationTicker // Animation ticker for conversation states
+	globalAnimState ui.GlobalAnimationSummary // Global animation state for status bar
+	err             error
+	width           int
+	height          int
+	ready           bool
+	showHelp        bool // Whether to show help screen
 }
 
 // NewModel creates a new application model
@@ -155,19 +157,26 @@ func NewModel(args *Args) Model {
 	if err != nil {
 		logger.Fatal("Failed to initialize message database: %v", err)
 	}
+
+	// Create animation ticker
+	animTicker := ui.NewAnimationTicker()
+
 	diffView.SetMessaging(mdb)
+	diffView.SetAnimationTicker(animTicker)
 	fileList.SetMessaging(mdb)
+	fileList.SetAnimationTicker(animTicker)
 
 	return Model{
-		fileList:      fileList,
-		diffView:      diffView,
-		commentEditor: ui.NewCommentEditor(),
-		layout:        ui.NewLayoutModel(),
-		bases:         args.Bases,
-		currentBase:   0, // Start with first base
-		paths:         args.Paths,
-		extensions:    args.Extensions,
-		messaging:     mdb,
+		fileList:        fileList,
+		diffView:        diffView,
+		commentEditor:   ui.NewCommentEditor(),
+		layout:          ui.NewLayoutModel(),
+		bases:           args.Bases,
+		currentBase:     0, // Start with first base
+		paths:           args.Paths,
+		extensions:      args.Extensions,
+		messaging:       mdb,
+		animationTicker: animTicker,
 	}
 }
 
@@ -181,7 +190,8 @@ func (m Model) Init() tea.Cmd {
 	cmds := []tea.Cmd{
 		initBaseResolverCmd(&m),
 		loadDiffCmd(&m),
-		disableTerminalLineWrap, // This now handles alternate screen + nowrap
+		disableTerminalLineWrap,        // This now handles alternate screen + nowrap
+		ui.StartAnimationTicker(),      // Start animation ticker
 	}
 
 	return tea.Batch(cmds...)
@@ -420,6 +430,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
+	case ui.AnimationTickMsg:
+		// Advance animation frame
+		m.animationTicker.Tick()
+		// Update global animation state based on conversations
+		m.updateGlobalAnimationState()
+		// Continue the ticker
+		cmds = append(cmds, ui.StartAnimationTicker())
+
 	default:
 		// Route other messages to diff view (like diffRenderedMsg)
 		cmd := m.diffView.Update(msg)
@@ -500,6 +518,13 @@ func (m Model) View() string {
 func (m Model) renderStatusBar() string {
 	var parts []string
 
+	// Show animation indicator if there are conversations needing attention
+	animState := ui.GetGlobalAnimationState(m.globalAnimState)
+	if animState != ui.NoAnimation {
+		animFrame := m.animationTicker.GetFrame(animState, false)
+		parts = append(parts, animFrame)
+	}
+
 	// Show current base
 	if len(m.bases) > 0 {
 		base := m.bases[m.currentBase]
@@ -535,6 +560,45 @@ func (m Model) renderStatusBar() string {
 		MaxWidth(m.width).
 		Inline(true).
 		Render(status)
+}
+
+// updateGlobalAnimationState updates the global animation state based on all conversations
+func (m *Model) updateGlobalAnimationState() {
+	m.globalAnimState = ui.GlobalAnimationSummary{
+		HasThinking:  false,
+		HasLookHere:  false,
+	}
+
+	if m.messaging == nil {
+		return
+	}
+
+	// Get all unresolved conversations
+	conversations, err := m.messaging.GetConversations(string(critic.StatusUnresolved))
+	if err != nil {
+		return
+	}
+
+	for _, conv := range conversations {
+		// Get the full conversation to check ReadByAI and last message
+		fullConv, err := m.messaging.GetFullConversation(conv.UUID)
+		if err != nil {
+			continue
+		}
+
+		state := ui.GetConversationAnimationState(fullConv)
+		switch state {
+		case ui.ThinkingAnimation:
+			m.globalAnimState.HasThinking = true
+		case ui.LookHereAnimation:
+			m.globalAnimState.HasLookHere = true
+		}
+
+		// Early exit if both are already true
+		if m.globalAnimState.HasThinking && m.globalAnimState.HasLookHere {
+			return
+		}
+	}
 }
 
 // renderError renders an error message

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -308,6 +308,12 @@ func (s *Server) handleGetFullCriticConversation(req Request, params CallToolPar
 		return s.sendToolError(req.ID, fmt.Sprintf("Error getting conversation: %v", err))
 	}
 
+	// Mark the conversation as read by AI
+	if err := s.messaging.MarkAsReadByAI(uuid); err != nil {
+		s.logToStderr("Failed to mark conversation as read by AI: %v", err)
+		// Don't fail the request, just log the error
+	}
+
 	// Convert to JSON response format
 	messages := make([]MessageResponse, len(conversation.Messages))
 	for i, msg := range conversation.Messages {

--- a/internal/messagedb/messagedb.go
+++ b/internal/messagedb/messagedb.go
@@ -44,6 +44,7 @@ type Message struct {
 	Author         Author
 	Status         Status
 	ReadStatus     ReadStatus
+	ReadByAI       bool   // Whether the AI has read this conversation via MCP
 	Message        string
 	FilePath       string // File this message is attached to (git-relative path)
 	Lineno         int    // Line number in the file
@@ -177,9 +178,9 @@ func (db *DB) CreateReply(author Author, message, conversationID string) (*Messa
 func (db *DB) insertMessage(msg *Message) error {
 	query := `
 		INSERT INTO messages (
-			id, author, status, read_status, message, file_path, lineno,
+			id, author, status, read_status, read_by_ai, message, file_path, lineno,
 			conversation_id, sha1, context, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
 	_, err := db.db.Exec(query,
@@ -187,6 +188,7 @@ func (db *DB) insertMessage(msg *Message) error {
 		string(msg.Author),
 		string(msg.Status),
 		string(msg.ReadStatus),
+		lo.Ternary(msg.ReadByAI, 1, 0),
 		msg.Message,
 		msg.FilePath,
 		msg.Lineno,
@@ -205,19 +207,21 @@ func (db *DB) GetMessage(id string) (*Message, error) {
 	preconditions.Check(id != "", "id must not be empty")
 
 	query := `
-		SELECT id, author, status, read_status, message, file_path, lineno,
+		SELECT id, author, status, read_status, read_by_ai, message, file_path, lineno,
 		       conversation_id, sha1, context, created_at, updated_at
 		FROM messages
 		WHERE id = ?
 	`
 
 	var msg Message
+	var readByAI int
 
 	err := db.db.QueryRow(query, id).Scan(
 		&msg.ID,
 		&msg.Author,
 		&msg.Status,
 		&msg.ReadStatus,
+		&readByAI,
 		&msg.Message,
 		&msg.FilePath,
 		&msg.Lineno,
@@ -235,6 +239,7 @@ func (db *DB) GetMessage(id string) (*Message, error) {
 		return nil, fmt.Errorf("failed to get message: %w", err)
 	}
 
+	msg.ReadByAI = readByAI != 0
 	return &msg, nil
 }
 
@@ -244,7 +249,7 @@ func (db *DB) GetThreadMessages(conversationID string) ([]*Message, error) {
 
 	// Get all messages with the same conversation_id
 	query := `
-		SELECT id, author, status, read_status, message, file_path, lineno,
+		SELECT id, author, status, read_status, read_by_ai, message, file_path, lineno,
 		       conversation_id, sha1, context, created_at, updated_at
 		FROM messages
 		WHERE conversation_id = ?
@@ -260,12 +265,14 @@ func (db *DB) GetThreadMessages(conversationID string) ([]*Message, error) {
 	var messages []*Message
 	for rows.Next() {
 		var msg Message
+		var readByAI int
 
 		err := rows.Scan(
 			&msg.ID,
 			&msg.Author,
 			&msg.Status,
 			&msg.ReadStatus,
+			&readByAI,
 			&msg.Message,
 			&msg.FilePath,
 			&msg.Lineno,
@@ -279,6 +286,7 @@ func (db *DB) GetThreadMessages(conversationID string) ([]*Message, error) {
 			return nil, fmt.Errorf("failed to scan message: %w", err)
 		}
 
+		msg.ReadByAI = readByAI != 0
 		messages = append(messages, &msg)
 	}
 
@@ -288,7 +296,7 @@ func (db *DB) GetThreadMessages(conversationID string) ([]*Message, error) {
 // GetUnresolvedRootMessages retrieves all unresolved root messages (not replies)
 func (db *DB) GetUnresolvedRootMessages() ([]*Message, error) {
 	query := `
-		SELECT id, author, status, read_status, message, file_path, lineno,
+		SELECT id, author, status, read_status, read_by_ai, message, file_path, lineno,
 		       conversation_id, sha1, context, created_at, updated_at
 		FROM messages
 		WHERE status != ? AND id = conversation_id
@@ -304,12 +312,14 @@ func (db *DB) GetUnresolvedRootMessages() ([]*Message, error) {
 	var messages []*Message
 	for rows.Next() {
 		var msg Message
+		var readByAI int
 
 		err := rows.Scan(
 			&msg.ID,
 			&msg.Author,
 			&msg.Status,
 			&msg.ReadStatus,
+			&readByAI,
 			&msg.Message,
 			&msg.FilePath,
 			&msg.Lineno,
@@ -323,6 +333,7 @@ func (db *DB) GetUnresolvedRootMessages() ([]*Message, error) {
 			return nil, fmt.Errorf("failed to scan message: %w", err)
 		}
 
+		msg.ReadByAI = readByAI != 0
 		messages = append(messages, &msg)
 	}
 
@@ -335,7 +346,7 @@ func (db *DB) GetMessagesByFile(filePath string) ([]*Message, error) {
 	preconditions.Check(filePath != "", "filePath must not be empty")
 
 	query := `
-		SELECT id, author, status, read_status, message, file_path, lineno,
+		SELECT id, author, status, read_status, read_by_ai, message, file_path, lineno,
 		       conversation_id, sha1, context, created_at, updated_at
 		FROM messages
 		WHERE file_path = ? AND id = conversation_id
@@ -351,12 +362,14 @@ func (db *DB) GetMessagesByFile(filePath string) ([]*Message, error) {
 	var messages []*Message
 	for rows.Next() {
 		var msg Message
+		var readByAI int
 
 		err := rows.Scan(
 			&msg.ID,
 			&msg.Author,
 			&msg.Status,
 			&msg.ReadStatus,
+			&readByAI,
 			&msg.Message,
 			&msg.FilePath,
 			&msg.Lineno,
@@ -370,6 +383,7 @@ func (db *DB) GetMessagesByFile(filePath string) ([]*Message, error) {
 			return nil, fmt.Errorf("failed to scan message: %w", err)
 		}
 
+		msg.ReadByAI = readByAI != 0
 		messages = append(messages, &msg)
 	}
 
@@ -435,6 +449,26 @@ func (db *DB) MarkAsRead(id string) error {
 	}
 
 	logger.Debug("Marked AI message %s as read", id)
+	return nil
+}
+
+// MarkAsReadByAI marks a conversation as having been read by the AI
+func (db *DB) MarkAsReadByAI(conversationID string) error {
+	preconditions.Check(conversationID != "", "conversationID must not be empty")
+
+	query := `
+		UPDATE messages
+		SET read_by_ai = 1, updated_at = ?
+		WHERE conversation_id = ?
+	`
+
+	result, err := db.db.Exec(query, time.Now(), conversationID)
+	if err != nil {
+		return fmt.Errorf("failed to mark as read by AI: %w", err)
+	}
+
+	affected, _ := result.RowsAffected()
+	logger.Info("Marked conversation %s (%d messages) as read by AI", conversationID, affected)
 	return nil
 }
 

--- a/internal/messagedb/messagedb_test.go
+++ b/internal/messagedb/messagedb_test.go
@@ -308,3 +308,67 @@ func TestGetConversationsWithStatusFilter(t *testing.T) {
 	assert.Equals(t, len(resolved), 1, "expected 1 resolved conversation")
 	assert.Equals(t, resolved[0].UUID, conv3.ID, "expected conv3 in resolved conversations")
 }
+
+func TestMarkAsReadByAI(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Create parent message and replies
+	parent, err := db.CreateMessage(AuthorHuman, "Parent comment", "src/main.go", 10, "abc123", "content")
+	assert.NoError(t, err, "failed to create parent")
+	assert.False(t, parent.ReadByAI, "expected ReadByAI to be false initially")
+
+	// Create replies
+	reply1, err := db.CreateReply(AuthorAI, "AI reply", parent.ID)
+	assert.NoError(t, err, "failed to create reply1")
+
+	reply2, err := db.CreateReply(AuthorHuman, "Human reply", parent.ID)
+	assert.NoError(t, err, "failed to create reply2")
+
+	// Mark conversation as read by AI
+	err = db.MarkAsReadByAI(parent.ID)
+	assert.NoError(t, err, "failed to mark as read by AI")
+
+	// Verify all messages in conversation are marked
+	parentAfter, _ := db.GetMessage(parent.ID)
+	assert.True(t, parentAfter.ReadByAI, "expected parent to be marked as read by AI")
+
+	reply1After, _ := db.GetMessage(reply1.ID)
+	assert.True(t, reply1After.ReadByAI, "expected reply1 to be marked as read by AI")
+
+	reply2After, _ := db.GetMessage(reply2.ID)
+	assert.True(t, reply2After.ReadByAI, "expected reply2 to be marked as read by AI")
+}
+
+func TestReadByAIFieldInGetThreadMessages(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Create conversation
+	parent, _ := db.CreateMessage(AuthorHuman, "Parent", "src/main.go", 10, "abc123", "content")
+	db.CreateReply(AuthorAI, "Reply", parent.ID)
+
+	// Mark as read by AI
+	db.MarkAsReadByAI(parent.ID)
+
+	// Get thread messages and verify ReadByAI field
+	thread, err := db.GetThreadMessages(parent.ID)
+	assert.NoError(t, err, "failed to get thread messages")
+	assert.Equals(t, len(thread), 2, "expected 2 messages in thread")
+
+	for _, msg := range thread {
+		assert.True(t, msg.ReadByAI, "expected message %s to be marked as read by AI", msg.ID)
+	}
+}
+
+func TestReadByAIFieldDefaultsFalse(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Create message
+	msg, _ := db.CreateMessage(AuthorHuman, "Comment", "src/main.go", 10, "abc123", "content")
+
+	// Verify ReadByAI defaults to false
+	retrieved, _ := db.GetMessage(msg.ID)
+	assert.False(t, retrieved.ReadByAI, "expected ReadByAI to default to false")
+}

--- a/internal/messagedb/messaging.go
+++ b/internal/messagedb/messaging.go
@@ -146,6 +146,7 @@ func (db *DB) GetFullConversation(conversationID string) (*critic.Conversation, 
 		Messages:    criticMessages,
 		CreatedAt:   rootMsg.CreatedAt,
 		UpdatedAt:   rootMsg.UpdatedAt,
+		ReadByAI:    rootMsg.ReadByAI,
 	}
 
 	logger.Debug("Retrieved conversation %s with %d messages", conversationID, len(criticMessages))

--- a/internal/messagedb/schema.go
+++ b/internal/messagedb/schema.go
@@ -7,7 +7,7 @@ import (
 	"git.15b.it/eno/critic/simple-go/logger"
 )
 
-const currentSchemaVersion = "2"
+const currentSchemaVersion = "3"
 
 // schema_v2 defines the v2 database schema with renamed columns and context
 var schema_v2 = `
@@ -41,6 +41,40 @@ var schema_v2 = `
 	CREATE INDEX IF NOT EXISTS idx_messages_read_status ON messages(read_status) WHERE author = 'ai';
 `
 
+// schema_v3 adds read_by_ai column for tracking AI-read conversations
+var schema_v3 = `
+	-- Settings table for metadata
+	CREATE TABLE IF NOT EXISTS settings (
+		key TEXT PRIMARY KEY,
+		value TEXT NOT NULL
+	);
+
+	-- Messages table for threaded comments
+	CREATE TABLE IF NOT EXISTS messages (
+		id TEXT PRIMARY KEY,
+		author TEXT NOT NULL CHECK(author IN ('human', 'ai')),
+		status TEXT NOT NULL CHECK(status IN ('new', 'delivered', 'resolved')),
+		read_status TEXT NOT NULL DEFAULT 'read' CHECK(read_status IN ('unread', 'read')),
+		read_by_ai INTEGER NOT NULL DEFAULT 0,
+		message TEXT NOT NULL,
+		file_path TEXT NOT NULL,
+		lineno INTEGER NOT NULL,
+		conversation_id TEXT NOT NULL,
+		sha1 TEXT NOT NULL,
+		context TEXT,
+		created_at TIMESTAMP NOT NULL,
+		updated_at TIMESTAMP NOT NULL,
+		FOREIGN KEY (conversation_id) REFERENCES messages(id) ON DELETE CASCADE
+	);
+
+	-- Indexes for performance
+	CREATE INDEX IF NOT EXISTS idx_messages_status ON messages(status);
+	CREATE INDEX IF NOT EXISTS idx_messages_file_path ON messages(file_path);
+	CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id);
+	CREATE INDEX IF NOT EXISTS idx_messages_read_status ON messages(read_status) WHERE author = 'ai';
+	CREATE INDEX IF NOT EXISTS idx_messages_read_by_ai ON messages(read_by_ai);
+`
+
 // initSchema creates the database schema if it doesn't exist
 func (db *DB) initSchema() error {
 	// Check if we need to initialize
@@ -65,8 +99,8 @@ func (db *DB) initSchema() error {
 
 // createInitialSchema creates all tables and initial data
 func (db *DB) createInitialSchema() error {
-	// Create tables using schema v2
-	_, err := db.db.Exec(schema_v2)
+	// Create tables using schema v3
+	_, err := db.db.Exec(schema_v3)
 	if err != nil {
 		return fmt.Errorf("failed to create schema: %w", err)
 	}

--- a/internal/ui/animation.go
+++ b/internal/ui/animation.go
@@ -1,0 +1,204 @@
+package ui
+
+import (
+	"sync"
+	"time"
+
+	"git.15b.it/eno/critic/pkg/critic"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// AnimationState represents the current animation state for conversations
+type AnimationState int
+
+const (
+	// NoAnimation - conversation is not read by AI or is resolved
+	NoAnimation AnimationState = iota
+	// ThinkingAnimation - read by AI but not answered (last message is human)
+	ThinkingAnimation
+	// LookHereAnimation - read by AI and answered (last message is AI) but not resolved
+	LookHereAnimation
+)
+
+// Animation frames for different states
+// Each frame should be single-width ASCII/Unicode characters
+
+// ThinkingFrames - dots animation for "thinking" state (10 chars)
+var ThinkingFrames = []string{
+	".         ",
+	"..        ",
+	"...       ",
+	"....      ",
+	".....     ",
+	"......    ",
+	".......   ",
+	"........  ",
+	"......... ",
+	"..........",
+	"......... ",
+	"........  ",
+	".......   ",
+	"......    ",
+	".....     ",
+	"....      ",
+	"...       ",
+	"..        ",
+}
+
+// ThinkingFramesShort - single char thinking animation
+var ThinkingFramesShort = []string{
+	".",
+	"o",
+	"O",
+	"o",
+}
+
+// LookHereFrames - jumping animation for "look here" state (10 chars)
+var LookHereFrames = []string{
+	">>        ",
+	" >>       ",
+	"  >>      ",
+	"   >>     ",
+	"    >>    ",
+	"     >>   ",
+	"      >>  ",
+	"       >> ",
+	"        >>",
+	"       >> ",
+	"      >>  ",
+	"     >>   ",
+	"    >>    ",
+	"   >>     ",
+	"  >>      ",
+	" >>       ",
+}
+
+// LookHereFramesShort - single char look here animation
+var LookHereFramesShort = []string{
+	">",
+	"*",
+	"<",
+	"*",
+}
+
+// AnimationTicker holds the current frame index and provides animation state
+type AnimationTicker struct {
+	mu           sync.RWMutex
+	frameIndex   int
+	tickInterval time.Duration
+}
+
+// NewAnimationTicker creates a new animation ticker
+func NewAnimationTicker() *AnimationTicker {
+	return &AnimationTicker{
+		tickInterval: 200 * time.Millisecond, // 200ms per frame
+	}
+}
+
+// GetFrame returns the current animation frame for the given state
+func (at *AnimationTicker) GetFrame(state AnimationState, long bool) string {
+	at.mu.RLock()
+	defer at.mu.RUnlock()
+
+	switch state {
+	case ThinkingAnimation:
+		if long {
+			return ThinkingFrames[at.frameIndex%len(ThinkingFrames)]
+		}
+		return ThinkingFramesShort[at.frameIndex%len(ThinkingFramesShort)]
+	case LookHereAnimation:
+		if long {
+			return LookHereFrames[at.frameIndex%len(LookHereFrames)]
+		}
+		return LookHereFramesShort[at.frameIndex%len(LookHereFramesShort)]
+	default:
+		if long {
+			return "          " // 10 spaces
+		}
+		return " "
+	}
+}
+
+// Tick advances the animation frame
+func (at *AnimationTicker) Tick() {
+	at.mu.Lock()
+	defer at.mu.Unlock()
+	at.frameIndex++
+}
+
+// AnimationTickMsg is sent when it's time to update animations
+type AnimationTickMsg struct{}
+
+// StartAnimationTicker returns a command that sends ticks every 200ms
+func StartAnimationTicker() tea.Cmd {
+	return tea.Tick(200*time.Millisecond, func(t time.Time) tea.Msg {
+		return AnimationTickMsg{}
+	})
+}
+
+// GetConversationAnimationState determines the animation state for a conversation
+// (A) ReadByAI and not answered (last message is human) => ThinkingAnimation
+// (B) ReadByAI and answered (last message is AI) but not resolved => LookHereAnimation
+// Otherwise => NoAnimation
+func GetConversationAnimationState(conv *critic.Conversation) AnimationState {
+	// Not read by AI - no animation
+	if !conv.ReadByAI {
+		return NoAnimation
+	}
+
+	// Resolved - no animation
+	if conv.Status == critic.StatusResolved {
+		return NoAnimation
+	}
+
+	// Check last message author
+	if len(conv.Messages) == 0 {
+		return NoAnimation
+	}
+
+	lastMsg := conv.Messages[len(conv.Messages)-1]
+	if lastMsg.Author == critic.AuthorAI {
+		// Last message is AI - look here animation (call to action for user)
+		return LookHereAnimation
+	}
+
+	// Last message is human - thinking animation (AI is working on it)
+	return ThinkingAnimation
+}
+
+// FileAnimationSummary holds animation info for a file
+type FileAnimationSummary struct {
+	HasThinking  bool
+	HasLookHere  bool
+}
+
+// GetFileAnimationState returns the animation state for a file
+// If file has any LookHere conversations, return LookHere (higher priority)
+// If file has any Thinking conversations, return Thinking
+// Otherwise return NoAnimation
+func GetFileAnimationState(summary FileAnimationSummary) AnimationState {
+	if summary.HasLookHere {
+		return LookHereAnimation
+	}
+	if summary.HasThinking {
+		return ThinkingAnimation
+	}
+	return NoAnimation
+}
+
+// GlobalAnimationSummary holds animation info for the entire app
+type GlobalAnimationSummary struct {
+	HasThinking  bool
+	HasLookHere  bool
+}
+
+// GetGlobalAnimationState returns the animation state for the status bar
+func GetGlobalAnimationState(summary GlobalAnimationSummary) AnimationState {
+	if summary.HasLookHere {
+		return LookHereAnimation
+	}
+	if summary.HasThinking {
+		return ThinkingAnimation
+	}
+	return NoAnimation
+}

--- a/internal/ui/animation_test.go
+++ b/internal/ui/animation_test.go
@@ -1,0 +1,173 @@
+package ui
+
+import (
+	"testing"
+
+	"git.15b.it/eno/critic/pkg/critic"
+	"git.15b.it/eno/critic/simple-go/assert"
+)
+
+func TestGetConversationAnimationState_NoAnimation(t *testing.T) {
+	// Test NoAnimation when not read by AI
+	conv := &critic.Conversation{
+		ReadByAI: false,
+		Status:   critic.StatusUnresolved,
+		Messages: []critic.Message{{Author: critic.AuthorHuman}},
+	}
+	state := GetConversationAnimationState(conv)
+	assert.Equals(t, state, NoAnimation, "expected NoAnimation when ReadByAI is false")
+
+	// Test NoAnimation when resolved
+	conv = &critic.Conversation{
+		ReadByAI: true,
+		Status:   critic.StatusResolved,
+		Messages: []critic.Message{{Author: critic.AuthorHuman}},
+	}
+	state = GetConversationAnimationState(conv)
+	assert.Equals(t, state, NoAnimation, "expected NoAnimation when Status is resolved")
+
+	// Test NoAnimation when no messages
+	conv = &critic.Conversation{
+		ReadByAI: true,
+		Status:   critic.StatusUnresolved,
+		Messages: []critic.Message{},
+	}
+	state = GetConversationAnimationState(conv)
+	assert.Equals(t, state, NoAnimation, "expected NoAnimation when no messages")
+}
+
+func TestGetConversationAnimationState_ThinkingAnimation(t *testing.T) {
+	// Test ThinkingAnimation when last message is human
+	conv := &critic.Conversation{
+		ReadByAI: true,
+		Status:   critic.StatusUnresolved,
+		Messages: []critic.Message{
+			{Author: critic.AuthorAI},
+			{Author: critic.AuthorHuman}, // Last message is human
+		},
+	}
+	state := GetConversationAnimationState(conv)
+	assert.Equals(t, state, ThinkingAnimation, "expected ThinkingAnimation when last message is human")
+
+	// Test with single human message
+	conv = &critic.Conversation{
+		ReadByAI: true,
+		Status:   critic.StatusUnresolved,
+		Messages: []critic.Message{
+			{Author: critic.AuthorHuman},
+		},
+	}
+	state = GetConversationAnimationState(conv)
+	assert.Equals(t, state, ThinkingAnimation, "expected ThinkingAnimation with single human message")
+}
+
+func TestGetConversationAnimationState_LookHereAnimation(t *testing.T) {
+	// Test LookHereAnimation when last message is AI
+	conv := &critic.Conversation{
+		ReadByAI: true,
+		Status:   critic.StatusUnresolved,
+		Messages: []critic.Message{
+			{Author: critic.AuthorHuman},
+			{Author: critic.AuthorAI}, // Last message is AI
+		},
+	}
+	state := GetConversationAnimationState(conv)
+	assert.Equals(t, state, LookHereAnimation, "expected LookHereAnimation when last message is AI")
+
+	// Test with single AI message
+	conv = &critic.Conversation{
+		ReadByAI: true,
+		Status:   critic.StatusUnresolved,
+		Messages: []critic.Message{
+			{Author: critic.AuthorAI},
+		},
+	}
+	state = GetConversationAnimationState(conv)
+	assert.Equals(t, state, LookHereAnimation, "expected LookHereAnimation with single AI message")
+}
+
+func TestAnimationTicker(t *testing.T) {
+	ticker := NewAnimationTicker()
+
+	// Test initial state
+	frame1 := ticker.GetFrame(ThinkingAnimation, false)
+	assert.Equals(t, frame1, ThinkingFramesShort[0], "expected first thinking frame")
+
+	// Test frame progression
+	ticker.Tick()
+	frame2 := ticker.GetFrame(ThinkingAnimation, false)
+	assert.Equals(t, frame2, ThinkingFramesShort[1], "expected second thinking frame after tick")
+
+	// Test long frame
+	ticker.Tick()
+	longFrame := ticker.GetFrame(LookHereAnimation, true)
+	expectedLongFrame := LookHereFrames[2%len(LookHereFrames)]
+	assert.Equals(t, longFrame, expectedLongFrame, "expected long look here frame")
+
+	// Test NoAnimation returns spaces
+	noAnimFrame := ticker.GetFrame(NoAnimation, false)
+	assert.Equals(t, noAnimFrame, " ", "expected space for NoAnimation short")
+
+	noAnimFrameLong := ticker.GetFrame(NoAnimation, true)
+	assert.Equals(t, noAnimFrameLong, "          ", "expected 10 spaces for NoAnimation long")
+}
+
+func TestGetFileAnimationState(t *testing.T) {
+	// Test NoAnimation
+	summary := FileAnimationSummary{
+		HasThinking:  false,
+		HasLookHere:  false,
+	}
+	state := GetFileAnimationState(summary)
+	assert.Equals(t, state, NoAnimation, "expected NoAnimation when no flags set")
+
+	// Test ThinkingAnimation
+	summary = FileAnimationSummary{
+		HasThinking:  true,
+		HasLookHere:  false,
+	}
+	state = GetFileAnimationState(summary)
+	assert.Equals(t, state, ThinkingAnimation, "expected ThinkingAnimation when HasThinking is true")
+
+	// Test LookHereAnimation takes priority
+	summary = FileAnimationSummary{
+		HasThinking:  true,
+		HasLookHere:  true,
+	}
+	state = GetFileAnimationState(summary)
+	assert.Equals(t, state, LookHereAnimation, "expected LookHereAnimation when both flags set (higher priority)")
+
+	// Test LookHereAnimation alone
+	summary = FileAnimationSummary{
+		HasThinking:  false,
+		HasLookHere:  true,
+	}
+	state = GetFileAnimationState(summary)
+	assert.Equals(t, state, LookHereAnimation, "expected LookHereAnimation when HasLookHere is true")
+}
+
+func TestGetGlobalAnimationState(t *testing.T) {
+	// Test NoAnimation
+	summary := GlobalAnimationSummary{
+		HasThinking:  false,
+		HasLookHere:  false,
+	}
+	state := GetGlobalAnimationState(summary)
+	assert.Equals(t, state, NoAnimation, "expected NoAnimation when no flags set")
+
+	// Test ThinkingAnimation
+	summary = GlobalAnimationSummary{
+		HasThinking:  true,
+		HasLookHere:  false,
+	}
+	state = GetGlobalAnimationState(summary)
+	assert.Equals(t, state, ThinkingAnimation, "expected ThinkingAnimation when HasThinking is true")
+
+	// Test LookHereAnimation takes priority
+	summary = GlobalAnimationSummary{
+		HasThinking:  true,
+		HasLookHere:  true,
+	}
+	state = GetGlobalAnimationState(summary)
+	assert.Equals(t, state, LookHereAnimation, "expected LookHereAnimation when both flags set (higher priority)")
+}

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -53,6 +53,7 @@ type DiffViewModel struct {
 	lineConversationUUID map[int]string // Maps rendered line number to conversation UUID
 	gotoBottomOnLoad     bool           // If true, go to bottom after next file load
 	filterMode           FilterMode     // Current filter mode for hunk filtering
+	animationTicker      *AnimationTicker // Animation ticker for conversation states
 }
 
 // NewDiffViewModel creates a new diff viewer model
@@ -675,6 +676,11 @@ func (m *DiffViewModel) SetMessaging(messaging critic.Messaging) {
 	m.messaging = messaging
 }
 
+// SetAnimationTicker sets the animation ticker for conversation state animations
+func (m *DiffViewModel) SetAnimationTicker(ticker *AnimationTicker) {
+	m.animationTicker = ticker
+}
+
 // SetFilterMode sets the filter mode for hunk filtering
 func (m *DiffViewModel) SetFilterMode(mode FilterMode) {
 	if m.filterMode != mode {
@@ -1143,11 +1149,23 @@ func (m *DiffViewModel) renderConversationPreview(conv *critic.Conversation, sta
 	// Build result: content lines, separator with hotkeys
 	var result []string
 
-	// Helper to create a content line (black text on light blue)
+	// Get animation state for this conversation
+	animState := GetConversationAnimationState(conv)
+	var animPrefix string
+	if m.animationTicker != nil && animState != NoAnimation {
+		animPrefix = m.animationTicker.GetFrame(animState, true) // 10-char long animation
+	} else {
+		animPrefix = "          " // 10 spaces when no animation
+	}
+
+	// Animation prefix width
+	const animPrefixWidth = 10
+
+	// Helper to create a content line (black text on light blue) with animation prefix
 	createContentLine := func(text string, lineNum int) string {
 		content := " " + text
 		visibleWidth := lipgloss.Width(content)
-		availableWidth := m.width
+		availableWidth := m.width - animPrefixWidth
 
 		var processed string
 		if visibleWidth > availableWidth {
@@ -1156,17 +1174,17 @@ func (m *DiffViewModel) renderConversationPreview(conv *critic.Conversation, sta
 			padding := strings.Repeat(" ", availableWidth-visibleWidth)
 			processed = content + padding
 		}
-		styled := lightBlueBg + blackFg + processed + reset
+		styled := animPrefix + lightBlueBg + blackFg + processed + reset
 		return m.renderLineWithCursor(styled, lineNum)
 	}
 
 	// Helper to create the separator line with optional hotkeys
 	createSeparatorLine := func(text string, lineNum int) string {
 		// Separator is a line of dashes with optional centered text
-		availableWidth := m.width
+		availableWidth := m.width - animPrefixWidth
 		if text == "" {
 			line := strings.Repeat("─", availableWidth)
-			styled := grayFg + line + reset
+			styled := animPrefix + grayFg + line + reset
 			return m.renderLineWithCursor(styled, lineNum)
 		}
 		// Center the text in the separator
@@ -1180,7 +1198,7 @@ func (m *DiffViewModel) renderConversationPreview(conv *critic.Conversation, sta
 			rightDashes = 0
 		}
 		line := strings.Repeat("─", leftDashes) + " " + text + " " + strings.Repeat("─", rightDashes)
-		styled := grayFg + line + reset
+		styled := animPrefix + grayFg + line + reset
 		return m.renderLineWithCursor(styled, lineNum)
 	}
 

--- a/internal/ui/filelist_widget.go
+++ b/internal/ui/filelist_widget.go
@@ -27,12 +27,13 @@ func (f FileItem) FilterValue() string {
 // FileListWidget is a teapot-based file list widget
 type FileListWidget struct {
 	pot.BaseWidget
-	list       *pot.SelectableList[FileItem]
-	messaging  critic.Messaging
-	width      int
-	height     int
-	filterMode int // 0 = all, 1 = with comments, 2 = unresolved only
-	totalFiles int // Total files before filtering (for "No files match filter" message)
+	list            *pot.SelectableList[FileItem]
+	messaging       critic.Messaging
+	animationTicker *AnimationTicker
+	width           int
+	height          int
+	filterMode      int // 0 = all, 1 = with comments, 2 = unresolved only
+	totalFiles      int // Total files before filtering (for "No files match filter" message)
 }
 
 // NewFileListWidget creates a new file list widget
@@ -66,6 +67,7 @@ func (w *FileListWidget) renderItem(buf *pot.SubBuffer, item FileItem, selected 
 	var hasUnreadAI bool
 	var hasUnresolved bool
 	var hasResolved bool
+	var fileAnimSummary FileAnimationSummary
 
 	if w.messaging != nil {
 		summary, err := w.messaging.GetFileConversationSummary(gitPath)
@@ -73,6 +75,11 @@ func (w *FileListWidget) renderItem(buf *pot.SubBuffer, item FileItem, selected 
 			hasUnreadAI = summary.HasUnreadAIMessages
 			hasUnresolved = summary.HasUnresolvedComments
 			hasResolved = summary.HasResolvedComments
+		}
+
+		// Get animation state for this file's conversations
+		if hasUnresolved {
+			fileAnimSummary = w.getFileAnimationSummary(gitPath)
 		}
 	}
 
@@ -94,10 +101,20 @@ func (w *FileListWidget) renderItem(buf *pot.SubBuffer, item FileItem, selected 
 		path = git.GitPathToDisplayPath(file.OldPath)
 	}
 
-	// Determine left indicator color
+	// Determine left indicator - animation takes priority
 	var indicatorStyle lipgloss.Style
 	var indicatorRune rune = ' '
-	if hasUnreadAI {
+	animState := GetFileAnimationState(fileAnimSummary)
+
+	if animState != NoAnimation && w.animationTicker != nil {
+		// Use animation character
+		animFrame := w.animationTicker.GetFrame(animState, false)
+		if len(animFrame) > 0 {
+			indicatorRune = []rune(animFrame)[0]
+		}
+		// Use yellow for animation indicators
+		indicatorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("220"))
+	} else if hasUnreadAI {
 		indicatorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196")) // Red
 		indicatorRune = '▌'
 	} else if hasUnresolved {
@@ -148,6 +165,36 @@ func (w *FileListWidget) renderItem(buf *pot.SubBuffer, item FileItem, selected 
 			buf.SetCell(x, 0, pot.Cell{Rune: ' ', Style: style})
 		}
 	}
+}
+
+// getFileAnimationSummary calculates the animation summary for a file
+func (w *FileListWidget) getFileAnimationSummary(gitPath string) FileAnimationSummary {
+	summary := FileAnimationSummary{}
+	if w.messaging == nil {
+		return summary
+	}
+
+	convs, err := w.messaging.GetConversationsForFile(gitPath)
+	if err != nil {
+		return summary
+	}
+
+	for _, conv := range convs {
+		state := GetConversationAnimationState(conv)
+		switch state {
+		case ThinkingAnimation:
+			summary.HasThinking = true
+		case LookHereAnimation:
+			summary.HasLookHere = true
+		}
+
+		// Early exit if both are true
+		if summary.HasThinking && summary.HasLookHere {
+			return summary
+		}
+	}
+
+	return summary
 }
 
 // SetFiles updates the file list
@@ -208,6 +255,11 @@ func (w *FileListWidget) OnSelect(fn func(*ctypes.FileDiff)) {
 // SetMessaging sets the messaging interface
 func (w *FileListWidget) SetMessaging(messaging critic.Messaging) {
 	w.messaging = messaging
+}
+
+// SetAnimationTicker sets the animation ticker for conversation state animations
+func (w *FileListWidget) SetAnimationTicker(ticker *AnimationTicker) {
+	w.animationTicker = ticker
 }
 
 // SetFilterMode sets the current filter mode and total files count

--- a/pkg/critic/messaging.go
+++ b/pkg/critic/messaging.go
@@ -43,6 +43,7 @@ type Conversation struct {
 	Messages    []Message // Root message + all replies, ordered by created_at
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+	ReadByAI    bool // Whether the AI has read this conversation via MCP
 }
 
 // FileConversationSummary contains information about conversations for a specific file
@@ -90,6 +91,9 @@ type Messaging interface {
 
 	// MarkAsRead marks an AI message as read
 	MarkAsRead(messageUUID string) error
+
+	// MarkAsReadByAI marks a conversation as having been read by the AI
+	MarkAsReadByAI(conversationUUID string) error
 
 	// Close closes the messaging system and releases resources
 	Close() error


### PR DESCRIPTION
Add tracking for when AI reads conversations via MCP, with visual feedback through animated indicators in the UI:

Database changes:
- Add read_by_ai column to messages table (schema v3)
- Add MarkAsReadByAI method to mark entire conversation as read by AI

MCP server changes:
- Mark conversation as read by AI when get_full_critic_conversation is called

Animation system:
- Add new animation.go with thinking and look-here animations
- Thinking animation (dots): shown when AI has read but not responded (last msg is human)
- Look here animation (>>): shown when AI has responded but not resolved (call to action)
- 10-character animation prefix in conversation preview
- Single-character animation in file list indicator
- Animation indicator in status bar when any conversation needs attention
- Animations update every 200ms

Tests:
- Add tests for MarkAsReadByAI and ReadByAI field persistence
- Add comprehensive tests for animation state logic