### PR TITLE
Refactor diff view into vertical hunk layout

### DIFF
--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -841,12 +841,17 @@ func (m *DiffViewModel) renderDiff() (string, int, []int) {
 	// Build line mappings and navigable lines from the widget structure
 	navigableLines := m.buildLineMappingsFromWidget(conversationsByLine)
 
-	// Apply cursor highlighting by updating selection in widget
-	m.updateWidgetSelection()
+	// Update widget selection for hotkey display in comments
+	m.diffWidget.SetSelectedRow(m.cursorLine)
 
-	// Re-render with selection
+	// Re-render with the updated selection (for hotkey display)
 	buffer.Clear()
 	m.diffWidget.Render(subBuf)
+
+	// Apply selection overlay - invert the current line if focused and navigable
+	if m.focused && m.isNavigableLine(m.cursorLine) {
+		buffer.InvertRow(m.cursorLine)
+	}
 
 	// Convert buffer to string
 	result := buffer.String()

--- a/internal/ui/diffview_widgets.go
+++ b/internal/ui/diffview_widgets.go
@@ -106,20 +106,20 @@ func (w *HunkWidget) Render(buf *teapot.SubBuffer) {
 	y++
 
 	// Render each line and its comment (if any)
+	// Note: Selection highlighting is done via buffer overlay, not here
 	for _, line := range w.hunk.Lines {
 		// Get highlighted content
 		highlighted := w.getHighlightedContent(line)
 
 		// Render the diff line
-		isSelected := (y == w.selectedRow)
-		w.renderDiffLine(buf, y, line, highlighted, width, isSelected)
+		w.renderDiffLine(buf, y, line, highlighted, width)
 		y++
 
 		// Render comment if exists
 		if line.NewNum > 0 {
 			if conv, exists := w.conversationMap[line.NewNum]; exists {
 				commentHeight := calculateCommentHeight(conv)
-				// Check if any row in comment is selected
+				// Check if any row in comment is selected (for hotkey display)
 				commentSelected := w.selectedRow >= y && w.selectedRow < y+commentHeight
 				w.renderComment(buf, y, conv, width, commentHeight, commentSelected)
 				y += commentHeight
@@ -164,8 +164,8 @@ func (w *HunkWidget) renderHeaderLine(buf *teapot.SubBuffer, y int, header strin
 	}
 }
 
-// renderDiffLine renders a single diff line.
-func (w *HunkWidget) renderDiffLine(buf *teapot.SubBuffer, y int, line *ctypes.Line, highlighted string, width int, selected bool) {
+// renderDiffLine renders a single diff line (selection highlighting is done via overlay).
+func (w *HunkWidget) renderDiffLine(buf *teapot.SubBuffer, y int, line *ctypes.Line, highlighted string, width int) {
 	if y >= buf.Height() {
 		return
 	}
@@ -198,9 +198,6 @@ func (w *HunkWidget) renderDiffLine(buf *teapot.SubBuffer, y int, line *ctypes.L
 	}
 
 	style := lipgloss.NewStyle().Background(bgColor)
-	if selected {
-		style = style.Reverse(true)
-	}
 
 	// Render prefix + content
 	content := prefix + highlighted
@@ -210,9 +207,6 @@ func (w *HunkWidget) renderDiffLine(buf *teapot.SubBuffer, y int, line *ctypes.L
 		if x < len(cells) {
 			cell = cells[x]
 			cell.Style = cell.Style.Background(bgColor)
-			if selected {
-				cell.Style = cell.Style.Reverse(true)
-			}
 		} else {
 			cell = teapot.Cell{Rune: ' ', Style: style}
 		}
@@ -255,15 +249,8 @@ func (w *HunkWidget) renderComment(buf *teapot.SubBuffer, startY int, conv *crit
 			var cell teapot.Cell
 			if x < len(cells) {
 				cell = cells[x]
-				if selected {
-					cell.Style = cell.Style.Reverse(true)
-				}
 			} else {
-				sepStyle := separatorStyle
-				if selected {
-					sepStyle = sepStyle.Reverse(true)
-				}
-				cell = teapot.Cell{Rune: '-', Style: sepStyle}
+				cell = teapot.Cell{Rune: '-', Style: separatorStyle}
 			}
 			buf.SetCell(x, y, cell)
 		}
@@ -301,15 +288,10 @@ func (w *HunkWidget) renderComment(buf *teapot.SubBuffer, startY int, conv *crit
 		contentLines[0] = "(Resolved) " + contentLines[0]
 	}
 
-	// Render content lines
+	// Render content lines (selection highlighting is done via overlay)
 	for _, line := range contentLines {
 		if y >= buf.Height() {
 			break
-		}
-
-		lineStyle := contentStyle
-		if selected {
-			lineStyle = lineStyle.Reverse(true)
 		}
 
 		content := " " + line
@@ -319,11 +301,8 @@ func (w *HunkWidget) renderComment(buf *teapot.SubBuffer, startY int, conv *crit
 			if x < len(cells) {
 				cell = cells[x]
 				cell.Style = cell.Style.Background(lightBlueBg).Foreground(blackFg)
-				if selected {
-					cell.Style = cell.Style.Reverse(true)
-				}
 			} else {
-				cell = teapot.Cell{Rune: ' ', Style: lineStyle}
+				cell = teapot.Cell{Rune: ' ', Style: contentStyle}
 			}
 			buf.SetCell(x, y, cell)
 		}
@@ -357,16 +336,12 @@ func (w *HunkWidget) renderComment(buf *teapot.SubBuffer, startY int, conv *crit
 		}
 
 		runes := []rune(bottomLine)
-		bottomSepStyle := separatorStyle
-		if selected {
-			bottomSepStyle = bottomSepStyle.Reverse(true)
-		}
 		for x := 0; x < width; x++ {
 			var r rune = '-'
 			if x < len(runes) {
 				r = runes[x]
 			}
-			buf.SetCell(x, y, teapot.Cell{Rune: r, Style: bottomSepStyle})
+			buf.SetCell(x, y, teapot.Cell{Rune: r, Style: separatorStyle})
 		}
 	}
 }

--- a/teapot/buffer.go
+++ b/teapot/buffer.go
@@ -519,6 +519,17 @@ func (s *SubBuffer) Sub(rect Rect) *SubBuffer {
 	}
 }
 
+// InvertRow applies Reverse styling to all cells in the specified row.
+// This is used for selection highlighting as an overlay effect.
+func (b *Buffer) InvertRow(row int) {
+	if row < 0 || row >= b.height {
+		return
+	}
+	for x := 0; x < b.width; x++ {
+		b.cells[row][x].Style = b.cells[row][x].Style.Reverse(true)
+	}
+}
+
 // String renders the buffer to a string for terminal output.
 // This is the final step before sending to the terminal.
 func (b *Buffer) String() string {


### PR DESCRIPTION
## Summary

Refactors the diff view pane from wrapping a single Teapot component to a widget-based vertical layout that stacks hunk displays on top of each other. Each hunk is rendered as a cohesive unit containing the header, diff lines, and inline comments.

### Key Changes

- **New widget architecture** (`diffview_widgets.go`):
  - `HunkWidget` - Primary building block that renders a complete hunk (header + lines + inline comments)
  - `DiffViewWidget` - Container that stacks HunkWidgets vertically with spacing
  - `FileHeaderWidget` - Renders file header information

- **Buffer overlay for selection highlighting**:
  - Added `Buffer.InvertRow()` method to apply Reverse styling to all cells in a row
  - Selection highlighting is now applied as a post-processing overlay after widget rendering
  - Cleanly separates content rendering from selection highlighting

- **Improved rendering flow**:
  - Widgets render content without selection styling
  - After rendering, the current line is inverted via buffer overlay
  - Widget still tracks `selectedRow` for hotkey display in comment separators

### Files Changed

- `internal/ui/diffview_widgets.go` - New file with widget implementations
- `internal/ui/diffview.go` - Updated to use widget-based rendering  
- `teapot/buffer.go` - Added `InvertRow()` and `Sub()` methods

## Test plan

- [ ] Verify diff lines render correctly with syntax highlighting
- [ ] Verify selection highlighting works on diff lines
- [ ] Verify selection highlighting works in comment sections
- [ ] Verify hotkeys appear in comment separator when cursor is in comment
- [ ] Verify scrolling works correctly
- [ ] Verify filter modes (with comments, with unresolved) work
