### PR TITLE
Add log file detection and CLI watcher

### DIFF
--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+
+	"git.15b.it/eno/critic/simple-go/logger"
+	"github.com/fsnotify/fsnotify"
+	"github.com/spf13/cobra"
+)
+
+// newLogCmd creates the log subcommand
+func newLogCmd() *cobra.Command {
+	var follow bool
+
+	cmd := &cobra.Command{
+		Use:   "log",
+		Short: "Watch and display the critic log file",
+		Long: `Watch and display the critic log file.
+
+By default, outputs the current log file path. Use -f to follow the log
+file and print new output as it arrives.
+
+Examples:
+  critic log        # Print the log file path
+  critic log -f     # Follow the log file (like tail -f)
+`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logPath := logger.LogFilePath()
+
+			if !follow {
+				fmt.Println(logPath)
+				return nil
+			}
+
+			return watchLogFile(logPath)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow the log file output")
+
+	return cmd
+}
+
+// watchLogFile watches the log file and prints new content to stdout
+func watchLogFile(logPath string) error {
+	// Open the log file
+	file, err := os.Open(logPath)
+	if err != nil {
+		return fmt.Errorf("failed to open log file: %w", err)
+	}
+	defer file.Close()
+
+	// Seek to end of file to only show new content
+	_, err = file.Seek(0, io.SeekEnd)
+	if err != nil {
+		return fmt.Errorf("failed to seek to end of file: %w", err)
+	}
+
+	// Create fsnotify watcher
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to create watcher: %w", err)
+	}
+	defer watcher.Close()
+
+	// Watch the log file
+	err = watcher.Add(logPath)
+	if err != nil {
+		return fmt.Errorf("failed to watch log file: %w", err)
+	}
+
+	reader := bufio.NewReader(file)
+
+	fmt.Fprintf(os.Stderr, "Watching %s...\n", logPath)
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+
+			if event.Op&fsnotify.Write == fsnotify.Write {
+				// Read and print new lines
+				for {
+					line, err := reader.ReadString('\n')
+					if err != nil {
+						break
+					}
+					fmt.Print(line)
+				}
+			}
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			return fmt.Errorf("watcher error: %w", err)
+		}
+	}
+}

--- a/internal/cli/parser.go
+++ b/internal/cli/parser.go
@@ -15,6 +15,7 @@ func Execute(handler func(*app.Args) error) error {
 	// Add subcommands
 	rootCmd.AddCommand(newMCPCmd())
 	rootCmd.AddCommand(newConvoCmd())
+	rootCmd.AddCommand(newLogCmd())
 
 	return rootCmd.Execute()
 }

--- a/simple-go/logger/logger.go
+++ b/simple-go/logger/logger.go
@@ -21,10 +21,11 @@ const (
 )
 
 var (
-	logger *log.Logger
-	once   sync.Once
-	level  Level = INFO // default log level
-	prefix string
+	logger      *log.Logger
+	once        sync.Once
+	level       Level = INFO // default log level
+	prefix      string
+	logFilePath string // stores the path to the current log file
 )
 
 func SetPrefix(s string) {
@@ -34,14 +35,28 @@ func SetPrefix(s string) {
 // ensureLogger initializes the logger if not already set
 func ensureLogger() {
 	once.Do(func() {
-		// Use ${TMPDIR:-/tmp}/critic.log as the log file
-		tmpDir := os.Getenv("TMPDIR")
-		if tmpDir == "" {
-			tmpDir = "/tmp"
-		}
-		logPath := filepath.Join(tmpDir, "critic.log")
-		logger = newFileLogger(logPath)
+		logFilePath = buildLogFilePath()
+		logger = newFileLogger(logFilePath)
 	})
+}
+
+// buildLogFilePath determines the log file path from the process name
+func buildLogFilePath() string {
+	tmpDir := os.Getenv("TMPDIR")
+	if tmpDir == "" {
+		tmpDir = "/tmp"
+	}
+
+	// Get the process name from os.Args[0]
+	processName := filepath.Base(os.Args[0])
+
+	return filepath.Join(tmpDir, processName+".log")
+}
+
+// LogFilePath returns the full path to the current log file
+func LogFilePath() string {
+	ensureLogger() // ensure the logger is initialized so logFilePath is set
+	return logFilePath
 }
 
 // newFileLogger creates a new file-based logger
@@ -61,6 +76,7 @@ func newNullLogger() *log.Logger {
 
 // SetLogFile sets the logger to write to a file
 func SetLogFile(path string) {
+	logFilePath = path
 	logger = newFileLogger(path)
 }
 


### PR DESCRIPTION
- Modified logger.go to determine log file path from process name (e.g., /tmp/critic.log from critic binary)
- Added LogFilePath() function to export the log file path
- Created new 'critic log' subcommand that:
  - Prints log file path by default
  - With -f/--follow flag, watches and tails the log file