### PR TITLE
Add CLI option to disable animations

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -43,9 +43,10 @@ func (m FilterMode) String() string {
 
 // Args represents parsed command-line arguments
 type Args struct {
-	Bases      []string // List of base points (e.g., ["main", "origin/main", "HEAD"])
-	Paths      []string // Paths to diff
-	Extensions []string // File extensions to include
+	Bases       []string // List of base points (e.g., ["main", "origin/main", "HEAD"])
+	Paths       []string // Paths to diff
+	Extensions  []string // File extensions to include
+	NoAnimation bool     // Disable animations
 }
 
 // GetDefaultBases returns the default base points based on git state
@@ -131,6 +132,7 @@ type Model struct {
 	messaging       critic.Messaging  // Messaging interface for conversations
 	filterMode      FilterMode        // Current filter mode (None, WithComments, WithUnresolved)
 	animationTicker *ui.AnimationTicker // Animation ticker for conversation states
+	noAnimation     bool                  // Whether animations are disabled
 	globalAnimState ui.GlobalAnimationSummary // Global animation state for status bar
 	tickCount       int                       // Debug: count of animation ticks
 	err             error
@@ -159,8 +161,11 @@ func NewModel(args *Args) Model {
 		logger.Fatal("Failed to initialize message database: %v", err)
 	}
 
-	// Create animation ticker
-	animTicker := ui.NewAnimationTicker()
+	// Create animation ticker (unless disabled)
+	var animTicker *ui.AnimationTicker
+	if !args.NoAnimation {
+		animTicker = ui.NewAnimationTicker()
+	}
 
 	diffView.SetMessaging(mdb)
 	diffView.SetAnimationTicker(animTicker)
@@ -178,6 +183,7 @@ func NewModel(args *Args) Model {
 		extensions:      args.Extensions,
 		messaging:       mdb,
 		animationTicker: animTicker,
+		noAnimation:     args.NoAnimation,
 	}
 }
 
@@ -192,7 +198,11 @@ func (m Model) Init() tea.Cmd {
 		initBaseResolverCmd(&m),
 		loadDiffCmd(&m),
 		disableTerminalLineWrap,        // This now handles alternate screen + nowrap
-		ui.StartAnimationTicker(),      // Start animation ticker
+	}
+
+	// Start animation ticker (unless disabled)
+	if !m.noAnimation {
+		cmds = append(cmds, ui.StartAnimationTicker())
 	}
 
 	return tea.Batch(cmds...)
@@ -432,6 +442,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case ui.AnimationTickMsg:
+		// Skip if animations are disabled
+		if m.noAnimation || m.animationTicker == nil {
+			return m, nil
+		}
 		// Advance animation frame
 		m.animationTicker.Tick()
 		// Update global animation state based on conversations

--- a/internal/cli/parser.go
+++ b/internal/cli/parser.go
@@ -42,6 +42,7 @@ func ParseArgsForTesting(args []string) (*app.Args, error) {
 // newRootCmd creates the root cobra command with the given handler
 func newRootCmd(handler func(*app.Args) error) *cobra.Command {
 	var extensionsFlag []string
+	var noAnimationFlag bool
 
 	cmd := &cobra.Command{
 		Use:   "critic [flags] [base1,base2,...] [-- path1 path2 ...]",
@@ -80,8 +81,9 @@ Examples:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Parse arguments
 			parsedArgs := &app.Args{
-				Extensions: ensureSlice(extensionsFlag),
-				Paths:      []string{"."},
+				Extensions:  ensureSlice(extensionsFlag),
+				Paths:       []string{"."},
+				NoAnimation: noAnimationFlag,
 			}
 
 			// Get paths after -- separator
@@ -117,6 +119,7 @@ Examples:
 
 	// Define flags
 	cmd.Flags().StringSliceVar(&extensionsFlag, "extensions", nil, "Comma-separated list of file extensions to include")
+	cmd.Flags().BoolVar(&noAnimationFlag, "no-animation", false, "Disable animations")
 
 	return cmd
 }


### PR DESCRIPTION
Adds a new --no-animation flag that disables the animation ticker entirely. When set, no AnimationTicker is created and the animation loop is not started, eliminating the repeated renderDiff logs and reducing CPU usage.