### PR TITLE
Cache filtering to reduce log messages

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -557,12 +557,13 @@ func (m Model) renderStatusBar() string {
 	parts = append(parts, fmt.Sprintf("[f]ilter: %s", m.filterMode.String()))
 
 	// Show file count (filtered count if filtering)
+	// Use cached filter info from fileList to avoid expensive re-filtering on every render
 	if m.diff != nil {
-		filteredFiles := m.filterFiles(m.diff.Files)
+		filteredCount, totalCount := m.fileList.GetFilterInfo()
 		if m.filterMode == FilterModeNone {
 			parts = append(parts, fmt.Sprintf("Files: %d", len(m.diff.Files)))
 		} else {
-			parts = append(parts, fmt.Sprintf("Files: %d/%d", len(filteredFiles), len(m.diff.Files)))
+			parts = append(parts, fmt.Sprintf("Files: %d/%d", filteredCount, totalCount))
 		}
 	}
 

--- a/internal/tui/filelist_widget.go
+++ b/internal/tui/filelist_widget.go
@@ -284,6 +284,12 @@ func (w *FileListWidget) SetFilterMode(filterMode int, totalFiles int) {
 	w.totalFiles = totalFiles
 }
 
+// GetFilterInfo returns the current filtered file count and total file count
+// This is used by the status bar to avoid re-filtering on every render
+func (w *FileListWidget) GetFilterInfo() (filteredCount, totalCount int) {
+	return len(w.list.Items()), w.totalFiles
+}
+
 // SetBounds implements pot.Widget
 func (w *FileListWidget) SetBounds(bounds pot.Rect) {
 	w.BaseWidget.SetBounds(bounds)


### PR DESCRIPTION
The renderStatusBar() function was calling filterFiles() on every UI render, causing 92+ SQL queries per render cycle. This change adds a GetFilterInfo() method to FileListWidget that returns cached filter counts, eliminating the expensive re-filtering in the status bar.