### PR TITLE
Replace SetCell (single cell writes) with SetCells (bulk writes using…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -38,7 +38,8 @@
       "Bash(go clean:*)",
       "Bash(go mod download:*)",
       "Bash(go list:*)",
-      "mcp__critic2__reply_to_critic_conversation"
+      "mcp__critic2__reply_to_critic_conversation",
+      "mcp__ide__getDiagnostics"
     ]
   }
 }

--- a/internal/tui/commenteditor.go
+++ b/internal/tui/commenteditor.go
@@ -139,15 +139,18 @@ func (h *conversationHistoryWidget) Render(buf *pot.SubBuffer) {
 
 		// Render with style
 		styled := historyStyle.Render(line)
-		cells := pot.ParseANSILine(styled)
+		parsedCells := pot.ParseANSILine(styled)
 
+		// Build row with padding
+		rowCells := make([]pot.Cell, width)
 		for x := 0; x < width; x++ {
-			if x < len(cells) {
-				buf.SetCell(x, y, cells[x])
+			if x < len(parsedCells) {
+				rowCells[x] = parsedCells[x]
 			} else {
-				buf.SetCell(x, y, pot.Cell{Rune: ' '})
+				rowCells[x] = pot.Cell{Rune: ' '}
 			}
 		}
+		buf.SetCells(0, y, rowCells)
 	}
 }
 
@@ -267,14 +270,18 @@ func (c *commentEditorContent) Render(buf *pot.SubBuffer) {
 	separatorStyle := lipgloss.NewStyle().Faint(true)
 	separator := strings.Repeat("─", width)
 	styled := separatorStyle.Render(separator)
-	cells := pot.ParseANSILine(styled)
+	parsedCells := pot.ParseANSILine(styled)
+
+	// Build row with padding
+	rowCells := make([]pot.Cell, width)
 	for x := 0; x < width; x++ {
-		if x < len(cells) {
-			buf.SetCell(x, separatorY, cells[x])
+		if x < len(parsedCells) {
+			rowCells[x] = parsedCells[x]
 		} else {
-			buf.SetCell(x, separatorY, pot.Cell{Rune: '─'})
+			rowCells[x] = pot.Cell{Rune: '─'}
 		}
 	}
+	buf.SetCells(0, separatorY, rowCells)
 
 	// Render textarea
 	textareaY := separatorY + 1
@@ -305,15 +312,18 @@ func (c *commentEditorContent) renderHistory(buf *pot.SubBuffer, startY, height,
 
 		// Render with style
 		styled := historyStyle.Render(line)
-		cells := pot.ParseANSILine(styled)
+		parsedCells := pot.ParseANSILine(styled)
 
+		// Build row with padding
+		rowCells := make([]pot.Cell, width)
 		for x := 0; x < width; x++ {
-			if x < len(cells) {
-				buf.SetCell(x, bufY, cells[x])
+			if x < len(parsedCells) {
+				rowCells[x] = parsedCells[x]
 			} else {
-				buf.SetCell(x, bufY, pot.Cell{Rune: ' '})
+				rowCells[x] = pot.Cell{Rune: ' '}
 			}
 		}
+		buf.SetCells(0, bufY, rowCells)
 	}
 }
 
@@ -334,15 +344,18 @@ func (c *commentEditorContent) renderTextarea(buf *pot.SubBuffer, startY, height
 			line = lines[y]
 		}
 
-		cells := pot.ParseANSILine(line)
+		parsedCells := pot.ParseANSILine(line)
 
+		// Build row with padding
+		rowCells := make([]pot.Cell, width)
 		for x := 0; x < width; x++ {
-			if x < len(cells) {
-				buf.SetCell(x, bufY, cells[x])
+			if x < len(parsedCells) {
+				rowCells[x] = parsedCells[x]
 			} else {
-				buf.SetCell(x, bufY, pot.Cell{Rune: ' '})
+				rowCells[x] = pot.Cell{Rune: ' '}
 			}
 		}
+		buf.SetCells(0, bufY, rowCells)
 	}
 }
 

--- a/internal/tui/diffview_widgets.go
+++ b/internal/tui/diffview_widgets.go
@@ -149,16 +149,17 @@ func (w *HunkWidget) renderHeaderLine(buf *teapot.SubBuffer, y int, header strin
 	if y >= buf.Height() {
 		return
 	}
+	// Build cells for the header line, padding with spaces
+	cells := make([]teapot.Cell, width)
 	runes := []rune(header)
 	for x := 0; x < width; x++ {
-		var cell teapot.Cell
 		if x < len(runes) {
-			cell = teapot.Cell{Rune: runes[x], Style: hunkHeaderStyle}
+			cells[x] = teapot.Cell{Rune: runes[x], Style: hunkHeaderStyle}
 		} else {
-			cell = teapot.Cell{Rune: ' ', Style: hunkHeaderStyle}
+			cells[x] = teapot.Cell{Rune: ' ', Style: hunkHeaderStyle}
 		}
-		buf.SetCell(x, y, cell)
 	}
+	buf.SetCells(0, y, cells)
 }
 
 // renderDiffLine renders a single diff line (selection highlighting is done via overlay).
@@ -198,17 +199,19 @@ func (w *HunkWidget) renderDiffLine(buf *teapot.SubBuffer, y int, line *ctypes.L
 
 	// Render prefix + content
 	content := prefix + highlighted
-	cells := teapot.ParseANSILine(content)
+	parsedCells := teapot.ParseANSILine(content)
+
+	// Build row of cells, padding with spaces
+	rowCells := make([]teapot.Cell, width)
 	for x := 0; x < width; x++ {
-		var cell teapot.Cell
-		if x < len(cells) {
-			cell = cells[x]
-			cell.Style = cell.Style.Background(bgColor)
+		if x < len(parsedCells) {
+			rowCells[x] = parsedCells[x]
+			rowCells[x].Style = rowCells[x].Style.Background(bgColor)
 		} else {
-			cell = teapot.Cell{Rune: ' ', Style: style}
+			rowCells[x] = teapot.Cell{Rune: ' ', Style: style}
 		}
-		buf.SetCell(x, y, cell)
 	}
+	buf.SetCells(0, y, rowCells)
 }
 
 // renderComment renders an inline comment/conversation.
@@ -232,15 +235,17 @@ func (w *HunkWidget) renderComment(buf *teapot.SubBuffer, startY int, conv *crit
 		// Render the animation frame (first 12 chars)
 		animFrame := GetSeparatorFrame()
 		animCells := teapot.ParseANSILine(animFrame)
-		for x := 0; x < len(animCells) && x < width; x++ {
-			buf.SetCell(x, y, animCells[x])
+		if len(animCells) > width {
+			animCells = animCells[:width]
 		}
+		buf.SetCells(0, y, animCells)
+
 		// Render the rest of the separator (space + dashes)
 		if width > 12 {
-			buf.SetCell(12, y, teapot.Cell{Rune: ' ', Style: separatorStyle})
+			buf.SetString(12, y, " ", separatorStyle)
 		}
-		for x := 13; x < width; x++ {
-			buf.SetCell(x, y, teapot.Cell{Rune: '-', Style: separatorStyle})
+		if width > 13 {
+			buf.SetString(13, y, strings.Repeat("-", width-13), separatorStyle)
 		}
 		y++
 	}
@@ -283,17 +288,19 @@ func (w *HunkWidget) renderComment(buf *teapot.SubBuffer, startY int, conv *crit
 		}
 
 		content := " " + line
-		cells := teapot.ParseANSILine(content)
+		parsedCells := teapot.ParseANSILine(content)
+
+		// Build row of cells with padding
+		rowCells := make([]teapot.Cell, width)
 		for x := 0; x < width; x++ {
-			var cell teapot.Cell
-			if x < len(cells) {
-				cell = cells[x]
-				cell.Style = cell.Style.Background(lightBlueBg).Foreground(blackFg)
+			if x < len(parsedCells) {
+				rowCells[x] = parsedCells[x]
+				rowCells[x].Style = rowCells[x].Style.Background(lightBlueBg).Foreground(blackFg)
 			} else {
-				cell = teapot.Cell{Rune: ' ', Style: contentStyle}
+				rowCells[x] = teapot.Cell{Rune: ' ', Style: contentStyle}
 			}
-			buf.SetCell(x, y, cell)
 		}
+		buf.SetCells(0, y, rowCells)
 		y++
 	}
 
@@ -323,14 +330,11 @@ func (w *HunkWidget) renderComment(buf *teapot.SubBuffer, startY int, conv *crit
 			bottomLine = strings.Repeat("-", leftDashes) + " " + separatorText + " " + strings.Repeat("-", rightDashes)
 		}
 
-		runes := []rune(bottomLine)
-		for x := 0; x < width; x++ {
-			var r rune = '-'
-			if x < len(runes) {
-				r = runes[x]
-			}
-			buf.SetCell(x, y, teapot.Cell{Rune: r, Style: separatorStyle})
+		// Pad to width if needed
+		if len(bottomLine) < width {
+			bottomLine += strings.Repeat("-", width-len(bottomLine))
 		}
+		buf.SetString(0, y, bottomLine, separatorStyle)
 	}
 }
 
@@ -366,23 +370,22 @@ func NewFileHeaderWidget(file *ctypes.FileDiff) *FileHeaderWidget {
 func (w *FileHeaderWidget) Render(buf *teapot.SubBuffer) {
 	width := buf.Width()
 
+	// Build header cells with padding
+	cells := make([]teapot.Cell, width)
 	runes := []rune(w.header)
 	for x := 0; x < width; x++ {
-		var cell teapot.Cell
 		if x < len(runes) {
-			cell = teapot.Cell{Rune: runes[x], Style: hunkHeaderStyle}
+			cells[x] = teapot.Cell{Rune: runes[x], Style: hunkHeaderStyle}
 		} else {
-			cell = teapot.Cell{Rune: ' ', Style: hunkHeaderStyle}
+			cells[x] = teapot.Cell{Rune: ' ', Style: hunkHeaderStyle}
 		}
-		buf.SetCell(x, 0, cell)
 	}
+	buf.SetCells(0, 0, cells)
 
 	// Blank second line
 	if buf.Height() > 1 {
 		emptyStyle := lipgloss.NewStyle()
-		for x := 0; x < width; x++ {
-			buf.SetCell(x, 1, teapot.Cell{Rune: ' ', Style: emptyStyle})
-		}
+		buf.SetString(0, 1, strings.Repeat(" ", width), emptyStyle)
 	}
 }
 
@@ -563,9 +566,7 @@ func (w *DiffViewWidget) Render(buf *teapot.SubBuffer) {
 		if hunkIdx < len(w.hunks)-1 {
 			if renderY >= 0 && renderY < height {
 				emptyStyle := lipgloss.NewStyle()
-				for x := 0; x < width; x++ {
-					buf.SetCell(x, renderY, teapot.Cell{Rune: ' ', Style: emptyStyle})
-				}
+				buf.SetString(0, renderY, strings.Repeat(" ", width), emptyStyle)
 			}
 			renderY++
 		}

--- a/internal/tui/filelist_widget.go
+++ b/internal/tui/filelist_widget.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 
 	"git.15b.it/eno/critic/internal/git"
 	"git.15b.it/eno/critic/pkg/critic"
@@ -129,10 +130,9 @@ func (w *FileListWidget) renderItem(buf *pot.SubBuffer, item FileItem, selected 
 		style = normalFileStyle
 	}
 
-	// Render indicator at column 0
-	buf.SetCell(0, 0, pot.Cell{Rune: indicatorRune, Style: indicatorStyle})
-	// Space after indicator at column 1
-	buf.SetCell(1, 0, pot.Cell{Rune: ' ', Style: style})
+	// Render indicator at column 0 and space at column 1
+	buf.SetString(0, 0, string(indicatorRune), indicatorStyle)
+	buf.SetString(1, 0, " ", style)
 
 	// Render content starting at column 2
 	content := fmt.Sprintf("%s %s", status, path)
@@ -149,14 +149,13 @@ func (w *FileListWidget) renderItem(buf *pot.SubBuffer, item FileItem, selected 
 	}
 
 	// Write content starting at column 2
-	for i, r := range runes {
-		buf.SetCell(2+i, 0, pot.Cell{Rune: r, Style: style})
-	}
+	buf.SetString(2, 0, string(runes), style)
 
 	// Fill remaining width with style (for selection highlight)
 	if selected {
-		for x := 2 + len(runes); x < width; x++ {
-			buf.SetCell(x, 0, pot.Cell{Rune: ' ', Style: style})
+		remaining := width - 2 - len(runes)
+		if remaining > 0 {
+			buf.SetString(2+len(runes), 0, strings.Repeat(" ", remaining), style)
 		}
 	}
 }

--- a/internal/tui/main_layout.go
+++ b/internal/tui/main_layout.go
@@ -3,6 +3,7 @@ package tui
 import (
 	pot "git.15b.it/eno/critic/teapot"
 	"git.15b.it/eno/critic/simple-go/logger"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // MainLayout is the root layout widget containing the main content and status bar.
@@ -96,7 +97,7 @@ func (m *MainLayout) Render(buf *pot.SubBuffer) {
 	// Render separator
 	separatorX := leftWidth
 	for y := 0; y < contentHeight; y++ {
-		buf.SetCell(separatorX, y, pot.Cell{Rune: '│'})
+		buf.SetString(separatorX, y, "│", lipgloss.NewStyle())
 	}
 
 	// Render diff view

--- a/internal/tui/statusbar_widget.go
+++ b/internal/tui/statusbar_widget.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"git.15b.it/eno/critic/teapot"
@@ -83,10 +84,9 @@ func (s *StatusBarWidget) Render(buf *teapot.SubBuffer) {
 	height := buf.Height()
 
 	// Fill background
+	bgRow := strings.Repeat(" ", width)
 	for y := 0; y < height; y++ {
-		for x := 0; x < width; x++ {
-			buf.SetCell(x, y, teapot.Cell{Rune: ' ', Style: s.cellStyle})
-		}
+		buf.SetString(0, y, bgRow, s.cellStyle)
 	}
 
 	// Build left section: [B]ase • [F]ilter • ? help

--- a/teapot/border.go
+++ b/teapot/border.go
@@ -1,6 +1,10 @@
 package teapot
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
 
 // BorderStyle defines the style of a border edge.
 type BorderStyle int
@@ -216,46 +220,42 @@ func RenderBorder(buf *SubBuffer, border Border) {
 	// Draw corners
 	if border.Top != BorderNone || border.Left != BorderNone {
 		corner := getCorner(border.Left, border.Top, "topLeft")
-		buf.SetCell(0, 0, Cell{Rune: corner, Style: border.Style})
+		buf.SetString(0, 0, string(corner), border.Style)
 	}
 	if border.Top != BorderNone || border.Right != BorderNone {
 		corner := getCorner(border.Right, border.Top, "topRight")
-		buf.SetCell(width-1, 0, Cell{Rune: corner, Style: border.Style})
+		buf.SetString(width-1, 0, string(corner), border.Style)
 	}
 	if border.Bottom != BorderNone || border.Left != BorderNone {
 		corner := getCorner(border.Left, border.Bottom, "bottomLeft")
-		buf.SetCell(0, height-1, Cell{Rune: corner, Style: border.Style})
+		buf.SetString(0, height-1, string(corner), border.Style)
 	}
 	if border.Bottom != BorderNone || border.Right != BorderNone {
 		corner := getCorner(border.Right, border.Bottom, "bottomRight")
-		buf.SetCell(width-1, height-1, Cell{Rune: corner, Style: border.Style})
+		buf.SetString(width-1, height-1, string(corner), border.Style)
 	}
 
 	// Draw top edge
 	if border.Top != BorderNone {
-		for x := 1; x < width-1; x++ {
-			buf.SetCell(x, 0, Cell{Rune: topChars.horizontal, Style: border.Style})
-		}
+		buf.SetString(1, 0, strings.Repeat(string(topChars.horizontal), width-2), border.Style)
 	}
 
 	// Draw bottom edge
 	if border.Bottom != BorderNone {
-		for x := 1; x < width-1; x++ {
-			buf.SetCell(x, height-1, Cell{Rune: bottomChars.horizontal, Style: border.Style})
-		}
+		buf.SetString(1, height-1, strings.Repeat(string(bottomChars.horizontal), width-2), border.Style)
 	}
 
 	// Draw left edge
 	if border.Left != BorderNone {
 		for y := 1; y < height-1; y++ {
-			buf.SetCell(0, y, Cell{Rune: leftChars.vertical, Style: border.Style})
+			buf.SetString(0, y, string(leftChars.vertical), border.Style)
 		}
 	}
 
 	// Draw right edge
 	if border.Right != BorderNone {
 		for y := 1; y < height-1; y++ {
-			buf.SetCell(width-1, y, Cell{Rune: rightChars.vertical, Style: border.Style})
+			buf.SetString(width-1, y, string(rightChars.vertical), border.Style)
 		}
 	}
 }
@@ -274,13 +274,16 @@ func RenderBorderTitle(buf *SubBuffer, title string, style lipgloss.Style) {
 		titleX = 1
 	}
 
-	for i, r := range titleRunes {
-		x := titleX + i
-		if x >= width-1 {
-			break
-		}
-		buf.SetCell(x, 0, Cell{Rune: r, Style: style})
+	// Truncate if needed to fit within borders
+	maxWidth := width - 2 - titleX
+	if maxWidth <= 0 {
+		return
 	}
+	if len(titleRunes) > maxWidth {
+		titleRunes = titleRunes[:maxWidth]
+	}
+
+	buf.SetString(titleX, 0, string(titleRunes), style)
 }
 
 // RenderBorderFooter renders text centered on the bottom border.
@@ -298,11 +301,14 @@ func RenderBorderFooter(buf *SubBuffer, footer string, style lipgloss.Style) {
 		footerX = 1
 	}
 
-	for i, r := range footerRunes {
-		x := footerX + i
-		if x >= width-1 {
-			break
-		}
-		buf.SetCell(x, height-1, Cell{Rune: r, Style: style})
+	// Truncate if needed to fit within borders
+	maxWidth := width - 2 - footerX
+	if maxWidth <= 0 {
+		return
 	}
+	if len(footerRunes) > maxWidth {
+		footerRunes = footerRunes[:maxWidth]
+	}
+
+	buf.SetString(footerX, height-1, string(footerRunes), style)
 }

--- a/teapot/buffer.go
+++ b/teapot/buffer.go
@@ -286,16 +286,6 @@ func (b *Buffer) Clear() {
 	}
 }
 
-// SetCell sets the cell at position (x, y).
-// Out of bounds writes are silently ignored.
-func (b *Buffer) SetCell(x, y int, cell Cell) {
-	if x < 0 || x >= b.width || y < 0 || y >= b.height {
-		return
-	}
-	b.markDirty()
-	b.cells[y][x] = cell
-}
-
 // GetCell returns the cell at position (x, y).
 // Out of bounds reads return an empty cell.
 func (b *Buffer) GetCell(x, y int) Cell {
@@ -305,23 +295,54 @@ func (b *Buffer) GetCell(x, y int) Cell {
 	return b.cells[y][x]
 }
 
-// SetString writes a string at position (x, y) with the given style.
-// Characters that extend beyond the buffer width are clipped.
-func (b *Buffer) SetString(x, y int, s string, style lipgloss.Style) {
-	if y < 0 || y >= b.height {
+// SetCells writes a slice of cells at position (x, y).
+// Cells that extend beyond the buffer width are clipped.
+// Uses copy for efficiency when possible.
+func (b *Buffer) SetCells(x, y int, cells []Cell) {
+	if y < 0 || y >= b.height || len(cells) == 0 {
 		return
 	}
 
 	b.markDirty()
-	for _, r := range s {
-		if x >= b.width {
-			break
+
+	// Handle negative x by skipping cells
+	if x < 0 {
+		skip := -x
+		if skip >= len(cells) {
+			return
 		}
-		if x >= 0 {
-			b.cells[y][x] = Cell{Rune: r, Style: style}
-		}
-		x++
+		cells = cells[skip:]
+		x = 0
 	}
+
+	// Clip to buffer width
+	available := b.width - x
+	if available <= 0 {
+		return
+	}
+	if len(cells) > available {
+		cells = cells[:available]
+	}
+
+	copy(b.cells[y][x:], cells)
+}
+
+// SetString writes a string at position (x, y) with the given style.
+// Characters that extend beyond the buffer width are clipped.
+func (b *Buffer) SetString(x, y int, s string, style lipgloss.Style) {
+	if y < 0 || y >= b.height || len(s) == 0 {
+		return
+	}
+
+	runes := []rune(s)
+
+	// Build cells slice
+	cells := make([]Cell, len(runes))
+	for i, r := range runes {
+		cells[i] = Cell{Rune: r, Style: style}
+	}
+
+	b.SetCells(x, y, cells)
 }
 
 // SetStringTruncated writes a string, truncating with ellipsis if needed.
@@ -376,37 +397,33 @@ func (b *Buffer) DrawBox(rect Rect, style lipgloss.Style) {
 		return
 	}
 
-	// Corners
-	b.SetCell(rect.X, rect.Y, Cell{Rune: '┌', Style: style})
-	b.SetCell(rect.X+rect.Width-1, rect.Y, Cell{Rune: '┐', Style: style})
-	b.SetCell(rect.X, rect.Y+rect.Height-1, Cell{Rune: '└', Style: style})
-	b.SetCell(rect.X+rect.Width-1, rect.Y+rect.Height-1, Cell{Rune: '┘', Style: style})
+	innerWidth := rect.Width - 2
 
-	// Top and bottom edges
-	for x := rect.X + 1; x < rect.X+rect.Width-1; x++ {
-		b.SetCell(x, rect.Y, Cell{Rune: '─', Style: style})
-		b.SetCell(x, rect.Y+rect.Height-1, Cell{Rune: '─', Style: style})
-	}
+	// Top edge: ┌───┐
+	topEdge := "┌" + strings.Repeat("─", innerWidth) + "┐"
+	b.SetString(rect.X, rect.Y, topEdge, style)
+
+	// Bottom edge: └───┘
+	bottomEdge := "└" + strings.Repeat("─", innerWidth) + "┘"
+	b.SetString(rect.X, rect.Y+rect.Height-1, bottomEdge, style)
 
 	// Left and right edges
 	for y := rect.Y + 1; y < rect.Y+rect.Height-1; y++ {
-		b.SetCell(rect.X, y, Cell{Rune: '│', Style: style})
-		b.SetCell(rect.X+rect.Width-1, y, Cell{Rune: '│', Style: style})
+		b.SetString(rect.X, y, "│", style)
+		b.SetString(rect.X+rect.Width-1, y, "│", style)
 	}
 }
 
 // DrawVerticalLine draws a vertical line at column x from y1 to y2.
 func (b *Buffer) DrawVerticalLine(x, y1, y2 int, style lipgloss.Style) {
 	for y := y1; y <= y2; y++ {
-		b.SetCell(x, y, Cell{Rune: '│', Style: style})
+		b.SetString(x, y, "│", style)
 	}
 }
 
 // DrawHorizontalLine draws a horizontal line at row y from x1 to x2.
 func (b *Buffer) DrawHorizontalLine(y, x1, x2 int, style lipgloss.Style) {
-	for x := x1; x <= x2; x++ {
-		b.SetCell(x, y, Cell{Rune: '─', Style: style})
-	}
+	b.SetString(x1, y, strings.Repeat("─", x2-x1+1), style)
 }
 
 // Blit copies the contents of another buffer into this one at the given offset.
@@ -484,14 +501,6 @@ func (s *SubBuffer) Bounds() Rect {
 	return Rect{X: 0, Y: 0, Width: s.offset.Width, Height: s.offset.Height}
 }
 
-// SetCell sets a cell at the given position (relative to sub-buffer origin).
-func (s *SubBuffer) SetCell(x, y int, cell Cell) {
-	if x < 0 || x >= s.offset.Width || y < 0 || y >= s.offset.Height {
-		return
-	}
-	s.parent.SetCell(s.offset.X+x, s.offset.Y+y, cell)
-}
-
 // GetCell returns the cell at the given position.
 func (s *SubBuffer) GetCell(x, y int) Cell {
 	if x < 0 || x >= s.offset.Width || y < 0 || y >= s.offset.Height {
@@ -500,20 +509,50 @@ func (s *SubBuffer) GetCell(x, y int) Cell {
 	return s.parent.GetCell(s.offset.X+x, s.offset.Y+y)
 }
 
-// SetString writes a string at the given position.
-func (s *SubBuffer) SetString(x, y int, str string, style lipgloss.Style) {
-	if y < 0 || y >= s.offset.Height {
+// SetCells writes a slice of cells at position (x, y) relative to sub-buffer origin.
+// Cells that extend beyond the sub-buffer width are clipped.
+func (s *SubBuffer) SetCells(x, y int, cells []Cell) {
+	if y < 0 || y >= s.offset.Height || len(cells) == 0 {
 		return
 	}
-	for _, r := range str {
-		if x >= s.offset.Width {
-			break
+
+	// Handle negative x by skipping cells
+	if x < 0 {
+		skip := -x
+		if skip >= len(cells) {
+			return
 		}
-		if x >= 0 {
-			s.SetCell(x, y, Cell{Rune: r, Style: style})
-		}
-		x++
+		cells = cells[skip:]
+		x = 0
 	}
+
+	// Clip to sub-buffer width
+	available := s.offset.Width - x
+	if available <= 0 {
+		return
+	}
+	if len(cells) > available {
+		cells = cells[:available]
+	}
+
+	s.parent.SetCells(s.offset.X+x, s.offset.Y+y, cells)
+}
+
+// SetString writes a string at the given position.
+func (s *SubBuffer) SetString(x, y int, str string, style lipgloss.Style) {
+	if y < 0 || y >= s.offset.Height || len(str) == 0 {
+		return
+	}
+
+	runes := []rune(str)
+
+	// Build cells slice
+	cells := make([]Cell, len(runes))
+	for i, r := range runes {
+		cells[i] = Cell{Rune: r, Style: style}
+	}
+
+	s.SetCells(x, y, cells)
 }
 
 // SetStringTruncated writes a string, truncating with ellipsis if needed.
@@ -537,10 +576,18 @@ func (s *SubBuffer) SetStringTruncated(x, y int, str string, maxWidth int, style
 // Fill fills a rectangular region.
 func (s *SubBuffer) Fill(rect Rect, cell Cell) {
 	clipped := rect.Intersect(s.Bounds())
+	if clipped.Width == 0 || clipped.Height == 0 {
+		return
+	}
+
+	// Build a row of cells to copy
+	row := make([]Cell, clipped.Width)
+	for i := range row {
+		row[i] = cell
+	}
+
 	for y := clipped.Y; y < clipped.Y+clipped.Height; y++ {
-		for x := clipped.X; x < clipped.X+clipped.Width; x++ {
-			s.SetCell(x, y, cell)
-		}
+		s.SetCells(clipped.X, y, row)
 	}
 }
 
@@ -596,11 +643,12 @@ func (s *SubBuffer) InvertRow(row int) {
 	if row < 0 || row >= s.offset.Height {
 		return
 	}
+	cells := make([]Cell, s.offset.Width)
 	for x := 0; x < s.offset.Width; x++ {
-		cell := s.GetCell(x, row)
-		cell.Style = cell.Style.Reverse(true)
-		s.SetCell(x, row, cell)
+		cells[x] = s.GetCell(x, row)
+		cells[x].Style = cells[x].Style.Reverse(true)
 	}
+	s.SetCells(0, row, cells)
 }
 
 // String renders the buffer to a string for terminal output.

--- a/teapot/buffer_test.go
+++ b/teapot/buffer_test.go
@@ -18,18 +18,25 @@ func TestBufferBasics(t *testing.T) {
 	assert.Equals(t, cell.Rune, ' ')
 }
 
-func TestBufferSetCell(t *testing.T) {
+func TestBufferSetCells(t *testing.T) {
 	buf := NewBuffer(10, 5)
 	style := lipgloss.NewStyle().Bold(true)
 
-	buf.SetCell(3, 2, Cell{Rune: 'X', Style: style})
-	cell := buf.GetCell(3, 2)
-	assert.Equals(t, cell.Rune, 'X')
+	cells := []Cell{{Rune: 'X', Style: style}, {Rune: 'Y', Style: style}}
+	buf.SetCells(3, 2, cells)
+	assert.Equals(t, buf.GetCell(3, 2).Rune, 'X')
+	assert.Equals(t, buf.GetCell(4, 2).Rune, 'Y')
 
-	// Out of bounds writes should be silently ignored
-	buf.SetCell(-1, 0, Cell{Rune: 'Y'})
-	buf.SetCell(100, 0, Cell{Rune: 'Y'})
-	// Should not panic
+	// Out of bounds writes should be clipped
+	buf.SetCells(-1, 0, []Cell{{Rune: 'A'}, {Rune: 'B'}, {Rune: 'C'}})
+	assert.Equals(t, buf.GetCell(0, 0).Rune, 'B')
+	assert.Equals(t, buf.GetCell(1, 0).Rune, 'C')
+
+	// Writes extending past buffer width should be clipped
+	buf.SetCells(8, 0, []Cell{{Rune: 'P'}, {Rune: 'Q'}, {Rune: 'R'}})
+	assert.Equals(t, buf.GetCell(8, 0).Rune, 'P')
+	assert.Equals(t, buf.GetCell(9, 0).Rune, 'Q')
+	// 'R' should not be written
 }
 
 func TestBufferSetString(t *testing.T) {
@@ -124,7 +131,7 @@ func TestBufferClone(t *testing.T) {
 	assert.Equals(t, clone.GetCell(1, 0).Rune, 'e')
 
 	// Modifying clone shouldn't affect original
-	clone.SetCell(0, 0, Cell{Rune: 'X'})
+	clone.SetString(0, 0, "X", style)
 	assert.Equals(t, buf.GetCell(0, 0).Rune, 'H')
 	assert.Equals(t, clone.GetCell(0, 0).Rune, 'X')
 }

--- a/teapot/layout.go
+++ b/teapot/layout.go
@@ -1,6 +1,8 @@
 package teapot
 
 import (
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -365,16 +367,14 @@ func (s *Split) Render(buf *SubBuffer) {
 			dividerX = s.first.Bounds().Width
 		}
 		for y := 0; y < buf.Height(); y++ {
-			buf.SetCell(dividerX, y, Cell{Rune: '│', Style: s.dividerStyle})
+			buf.SetString(dividerX, y, "│", s.dividerStyle)
 		}
 	} else {
 		dividerY := 0
 		if s.first != nil {
 			dividerY = s.first.Bounds().Height
 		}
-		for x := 0; x < buf.Width(); x++ {
-			buf.SetCell(x, dividerY, Cell{Rune: '─', Style: s.dividerStyle})
-		}
+		buf.SetString(0, dividerY, strings.Repeat("─", buf.Width()), s.dividerStyle)
 	}
 
 	// Render children

--- a/teapot/layout_test.go
+++ b/teapot/layout_test.go
@@ -25,10 +25,12 @@ func (m *mockWidget) Render(buf *SubBuffer) {
 	// Fill with first char of id for visual debugging
 	if len(m.id) > 0 {
 		r := rune(m.id[0])
+		row := make([]Cell, buf.Width())
+		for i := range row {
+			row[i] = Cell{Rune: r}
+		}
 		for y := 0; y < buf.Height(); y++ {
-			for x := 0; x < buf.Width(); x++ {
-				buf.SetCell(x, y, Cell{Rune: r})
-			}
+			buf.SetCells(0, y, row)
 		}
 	}
 }

--- a/teapot/legacy.go
+++ b/teapot/legacy.go
@@ -80,14 +80,7 @@ func (l *LegacyAdapter) renderString(buf *SubBuffer, s string) {
 
 		// For now, just render the raw characters
 		// In a full implementation, we'd parse ANSI escape sequences
-		x := 0
-		for _, r := range line {
-			if x >= buf.Width() {
-				break
-			}
-			buf.SetCell(x, y, Cell{Rune: r})
-			x++
-		}
+		buf.SetString(0, y, line, noStyle)
 	}
 }
 
@@ -157,15 +150,7 @@ func (s *StringWidget) Render(buf *SubBuffer) {
 		if y >= buf.Height() {
 			break
 		}
-
-		x := 0
-		for _, r := range line {
-			if x >= buf.Width() {
-				break
-			}
-			buf.SetCell(x, y, Cell{Rune: r})
-			x++
-		}
+		buf.SetString(0, y, line, noStyle)
 	}
 }
 

--- a/teapot/list.go
+++ b/teapot/list.go
@@ -1,6 +1,8 @@
 package teapot
 
 import (
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -200,8 +202,9 @@ func (l *SelectableList[T]) Render(buf *SubBuffer) {
 			lineBuf.SetStringTruncated(0, 0, text, buf.Width(), style)
 
 			// Fill remaining width with style background
-			for x := len(text); x < buf.Width(); x++ {
-				lineBuf.SetCell(x, 0, Cell{Rune: ' ', Style: style})
+			remaining := buf.Width() - len(text)
+			if remaining > 0 {
+				lineBuf.SetString(len(text), 0, strings.Repeat(" ", remaining), style)
 			}
 		}
 	}
@@ -382,13 +385,28 @@ func (s *ScrollView) Render(buf *SubBuffer) {
 		if srcY < 0 || srcY >= s.contentSize.Height {
 			continue
 		}
-		for x := 0; x < buf.Width(); x++ {
-			srcX := s.scrollX + x
-			if srcX < 0 || srcX >= s.contentSize.Width {
-				continue
-			}
-			buf.SetCell(x, y, contentBuf.GetCell(srcX, srcY))
+
+		// Calculate the range of cells to copy for this row
+		srcStartX := s.scrollX
+		if srcStartX < 0 {
+			srcStartX = 0
 		}
+		srcEndX := s.scrollX + buf.Width()
+		if srcEndX > s.contentSize.Width {
+			srcEndX = s.contentSize.Width
+		}
+		if srcStartX >= srcEndX {
+			continue
+		}
+
+		// Build a row of cells to copy
+		cells := make([]Cell, srcEndX-srcStartX)
+		for i := 0; i < len(cells); i++ {
+			cells[i] = contentBuf.GetCell(srcStartX+i, srcY)
+		}
+
+		destX := srcStartX - s.scrollX
+		buf.SetCells(destX, y, cells)
 	}
 }
 

--- a/teapot/stack.go
+++ b/teapot/stack.go
@@ -1,6 +1,8 @@
 package teapot
 
 import (
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -239,11 +241,12 @@ func (m *Modal) Render(buf *SubBuffer) {
 	if m.dimBackground {
 		dimStyle := lipgloss.NewStyle().Faint(true)
 		for y := 0; y < buf.Height(); y++ {
+			cells := make([]Cell, buf.Width())
 			for x := 0; x < buf.Width(); x++ {
-				cell := buf.GetCell(x, y)
-				cell.Style = dimStyle
-				buf.SetCell(x, y, cell)
+				cells[x] = buf.GetCell(x, y)
+				cells[x].Style = dimStyle
 			}
+			buf.SetCells(0, y, cells)
 		}
 	}
 
@@ -261,30 +264,30 @@ func (m *Modal) Render(buf *SubBuffer) {
 	}
 
 	// Fill background
+	bgRow := make([]Cell, modalRect.Width)
+	for i := range bgRow {
+		bgRow[i] = Cell{Rune: ' ', Style: m.bgStyle}
+	}
 	for y := modalRect.Y; y < modalRect.Y+modalRect.Height; y++ {
-		for x := modalRect.X; x < modalRect.X+modalRect.Width; x++ {
-			buf.SetCell(x, y, Cell{Rune: ' ', Style: m.bgStyle})
-		}
+		buf.SetCells(modalRect.X, y, bgRow)
 	}
 
 	// Draw border
 	if m.showBorder {
-		// Corners
-		buf.SetCell(modalRect.X, modalRect.Y, Cell{Rune: '┌', Style: m.borderStyle})
-		buf.SetCell(modalRect.X+modalRect.Width-1, modalRect.Y, Cell{Rune: '┐', Style: m.borderStyle})
-		buf.SetCell(modalRect.X, modalRect.Y+modalRect.Height-1, Cell{Rune: '└', Style: m.borderStyle})
-		buf.SetCell(modalRect.X+modalRect.Width-1, modalRect.Y+modalRect.Height-1, Cell{Rune: '┘', Style: m.borderStyle})
+		innerWidth := modalRect.Width - 2
 
-		// Top and bottom edges
-		for x := modalRect.X + 1; x < modalRect.X+modalRect.Width-1; x++ {
-			buf.SetCell(x, modalRect.Y, Cell{Rune: '─', Style: m.borderStyle})
-			buf.SetCell(x, modalRect.Y+modalRect.Height-1, Cell{Rune: '─', Style: m.borderStyle})
-		}
+		// Top edge: ┌───┐
+		topEdge := "┌" + strings.Repeat("─", innerWidth) + "┐"
+		buf.SetString(modalRect.X, modalRect.Y, topEdge, m.borderStyle)
+
+		// Bottom edge: └───┘
+		bottomEdge := "└" + strings.Repeat("─", innerWidth) + "┘"
+		buf.SetString(modalRect.X, modalRect.Y+modalRect.Height-1, bottomEdge, m.borderStyle)
 
 		// Left and right edges
 		for y := modalRect.Y + 1; y < modalRect.Y+modalRect.Height-1; y++ {
-			buf.SetCell(modalRect.X, y, Cell{Rune: '│', Style: m.borderStyle})
-			buf.SetCell(modalRect.X+modalRect.Width-1, y, Cell{Rune: '│', Style: m.borderStyle})
+			buf.SetString(modalRect.X, y, "│", m.borderStyle)
+			buf.SetString(modalRect.X+modalRect.Width-1, y, "│", m.borderStyle)
 		}
 
 		// Title

--- a/teapot/text.go
+++ b/teapot/text.go
@@ -148,9 +148,7 @@ func (s *StatusBar) Render(buf *SubBuffer) {
 	width := buf.Width()
 
 	// Fill background
-	for x := 0; x < width; x++ {
-		buf.SetCell(x, 0, Cell{Rune: ' ', Style: s.style})
-	}
+	buf.SetString(0, 0, strings.Repeat(" ", width), s.style)
 
 	// Render left
 	if s.left != "" {


### PR DESCRIPTION
… copy) for better efficiency.

- Removed: Buffer.SetCell and SubBuffer.SetCell
- Added: Buffer.SetCells(x, y int, cells []Cell) and SubBuffer.SetCells - uses copy() for efficient bulk writes with proper bounds clipping
- Updated: SetString now builds a []Cell slice and delegates to SetCells

- Updated Call Sites (11 files)