### PR TITLE
Run tests and fix failures

### DIFF
--- a/internal/git/line_displacement.go
+++ b/internal/git/line_displacement.go
@@ -540,5 +540,5 @@ func revParse(ref string) string {
 
 	// Use git rev-parse to get the SHA1
 	output := must.Exec("git", "rev-parse", ref)
-	return string(output)
+	return strings.TrimSpace(string(output))
 }

--- a/tests/integration/fixtures/make_repo.sh
+++ b/tests/integration/fixtures/make_repo.sh
@@ -7,6 +7,9 @@ rm -rf repo
 mkdir repo
 cd repo
 git init
+git config user.name "Test User"
+git config user.email "test@example.com"
+git config commit.gpgsign false
 for file in ../v*.txt ; do
 	cp $file data.txt
 	version=$(basename $file | sed 's-\..*--')

--- a/tests/integration/shared.go
+++ b/tests/integration/shared.go
@@ -34,6 +34,7 @@ func SetupGitRepo(t *testing.T) {
 	// Configure git
 	must.Exec("git", "config", "user.name", "Test User")
 	must.Exec("git", "config", "user.email", "test@example.com")
+	must.Exec("git", "config", "commit.gpgsign", "false")
 }
 
 // CommitFile commits an existing file in the current directory


### PR DESCRIPTION
- Disable commit signing in test repositories to fix failures in environments with global GPG signing enabled
- Trim whitespace from git rev-parse output in revParse() to fix newline character causing git show commands to fail