### PR TITLE
Add internal setString method without validation

### DIFF
--- a/teapot/border.go
+++ b/teapot/border.go
@@ -217,22 +217,22 @@ func RenderBorder(buf *SubBuffer, border Border) {
 	leftChars := borderCharSets[border.Left]
 	rightChars := borderCharSets[border.Right]
 
-	// Draw corners
+	// Draw corners (y values are valid since height >= 2, strings are single chars)
 	if border.Top != BorderNone || border.Left != BorderNone {
 		corner := getCorner(border.Left, border.Top, "topLeft")
-		buf.SetString(0, 0, string(corner), border.Style)
+		buf.setString(0, 0, string(corner), border.Style)
 	}
 	if border.Top != BorderNone || border.Right != BorderNone {
 		corner := getCorner(border.Right, border.Top, "topRight")
-		buf.SetString(width-1, 0, string(corner), border.Style)
+		buf.setString(width-1, 0, string(corner), border.Style)
 	}
 	if border.Bottom != BorderNone || border.Left != BorderNone {
 		corner := getCorner(border.Left, border.Bottom, "bottomLeft")
-		buf.SetString(0, height-1, string(corner), border.Style)
+		buf.setString(0, height-1, string(corner), border.Style)
 	}
 	if border.Bottom != BorderNone || border.Right != BorderNone {
 		corner := getCorner(border.Right, border.Bottom, "bottomRight")
-		buf.SetString(width-1, height-1, string(corner), border.Style)
+		buf.setString(width-1, height-1, string(corner), border.Style)
 	}
 
 	// Draw top edge
@@ -245,17 +245,17 @@ func RenderBorder(buf *SubBuffer, border Border) {
 		buf.SetString(1, height-1, strings.Repeat(string(bottomChars.horizontal), width-2), border.Style)
 	}
 
-	// Draw left edge
+	// Draw left edge (loop only executes when y values are valid)
 	if border.Left != BorderNone {
 		for y := 1; y < height-1; y++ {
-			buf.SetString(0, y, string(leftChars.vertical), border.Style)
+			buf.setString(0, y, string(leftChars.vertical), border.Style)
 		}
 	}
 
-	// Draw right edge
+	// Draw right edge (loop only executes when y values are valid)
 	if border.Right != BorderNone {
 		for y := 1; y < height-1; y++ {
-			buf.SetString(width-1, y, string(rightChars.vertical), border.Style)
+			buf.setString(width-1, y, string(rightChars.vertical), border.Style)
 		}
 	}
 }

--- a/teapot/buffer.go
+++ b/teapot/buffer.go
@@ -115,6 +115,13 @@ func (b *Buffer) GetCell(x, y int) Cell {
 	return b.cells[y][x]
 }
 
+// setCells is the internal implementation that writes cells without validation.
+// Preconditions: y is valid (0 <= y < height), x is valid (0 <= x < width),
+// cells is non-empty and fits within width.
+func (b *Buffer) setCells(x, y int, cells []Cell) {
+	copy(b.cells[y][x:], cells)
+}
+
 // SetCells writes a slice of cells at position (x, y).
 // Cells that extend beyond the buffer width are clipped.
 // Uses copy for efficiency when possible.
@@ -142,7 +149,41 @@ func (b *Buffer) SetCells(x, y int, cells []Cell) {
 		cells = cells[:available]
 	}
 
-	copy(b.cells[y][x:], cells)
+	b.setCells(x, y, cells)
+}
+
+// setString is the internal implementation that writes a string without validation.
+// Preconditions: y is valid (0 <= y < height), s is non-empty.
+// Handles x clipping internally.
+func (b *Buffer) setString(x, y int, s string, style lipgloss.Style) {
+	runes := []rune(s)
+
+	// Handle negative x by skipping runes
+	if x < 0 {
+		skip := -x
+		if skip >= len(runes) {
+			return
+		}
+		runes = runes[skip:]
+		x = 0
+	}
+
+	// Clip to buffer width
+	available := b.width - x
+	if available <= 0 {
+		return
+	}
+	if len(runes) > available {
+		runes = runes[:available]
+	}
+
+	// Build cells slice
+	cells := make([]Cell, len(runes))
+	for i, r := range runes {
+		cells[i] = Cell{Rune: r, Style: style}
+	}
+
+	b.setCells(x, y, cells)
 }
 
 // SetString writes a string at position (x, y) with the given style.
@@ -152,15 +193,7 @@ func (b *Buffer) SetString(x, y int, s string, style lipgloss.Style) {
 		return
 	}
 
-	runes := []rune(s)
-
-	// Build cells slice
-	cells := make([]Cell, len(runes))
-	for i, r := range runes {
-		cells[i] = Cell{Rune: r, Style: style}
-	}
-
-	b.SetCells(x, y, cells)
+	b.setString(x, y, s, style)
 }
 
 // SetStringTruncated writes a string, truncating with ellipsis if needed.
@@ -178,7 +211,11 @@ func (b *Buffer) SetStringTruncated(x, y int, s string, maxWidth int, style lipg
 		}
 	}
 
-	b.SetString(x, y, string(runes), style)
+	if len(runes) == 0 {
+		return
+	}
+
+	b.setString(x, y, string(runes), style)
 }
 
 // Fill fills a rectangular region with the given cell.

--- a/teapot/stack.go
+++ b/teapot/stack.go
@@ -236,15 +236,16 @@ func (m *Modal) SetBounds(bounds Rect) {
 // Render renders the modal with optional dimmed background.
 func (m *Modal) Render(buf *SubBuffer) {
 	// Dim background if enabled
-	if m.dimBackground {
+	if m.dimBackground && buf.Width() > 0 {
 		dimStyle := lipgloss.NewStyle().Faint(true)
+		// y values from 0 to Height()-1 are valid, cells is full width (non-empty)
 		for y := 0; y < buf.Height(); y++ {
 			cells := make([]Cell, buf.Width())
 			for x := 0; x < buf.Width(); x++ {
 				cells[x] = buf.GetCell(x, y)
 				cells[x].Style = dimStyle
 			}
-			buf.SetCells(0, y, cells)
+			buf.setCells(0, y, cells)
 		}
 	}
 

--- a/teapot/sub_buffer.go
+++ b/teapot/sub_buffer.go
@@ -48,6 +48,13 @@ func (s *SubBuffer) GetCell(x, y int) Cell {
 	return s.parent.GetCell(s.offset.X+x, s.offset.Y+y)
 }
 
+// setCells is the internal implementation that writes cells without validation.
+// Preconditions: y is valid (0 <= y < height), x is valid (0 <= x < width),
+// cells is non-empty and fits within width.
+func (s *SubBuffer) setCells(x, y int, cells []Cell) {
+	s.parent.setCells(s.offset.X+x, s.offset.Y+y, cells)
+}
+
 // SetCells writes a slice of cells at position (x, y) relative to sub-buffer origin.
 // Cells that extend beyond the sub-buffer width are clipped.
 func (s *SubBuffer) SetCells(x, y int, cells []Cell) {
@@ -74,7 +81,41 @@ func (s *SubBuffer) SetCells(x, y int, cells []Cell) {
 		cells = cells[:available]
 	}
 
-	s.parent.SetCells(s.offset.X+x, s.offset.Y+y, cells)
+	s.setCells(x, y, cells)
+}
+
+// setString is the internal implementation that writes a string without validation.
+// Preconditions: y is valid (0 <= y < height), str is non-empty.
+// Handles x clipping internally.
+func (s *SubBuffer) setString(x, y int, str string, style lipgloss.Style) {
+	runes := []rune(str)
+
+	// Handle negative x by skipping runes
+	if x < 0 {
+		skip := -x
+		if skip >= len(runes) {
+			return
+		}
+		runes = runes[skip:]
+		x = 0
+	}
+
+	// Clip to sub-buffer width
+	available := s.offset.Width - x
+	if available <= 0 {
+		return
+	}
+	if len(runes) > available {
+		runes = runes[:available]
+	}
+
+	// Build cells slice
+	cells := make([]Cell, len(runes))
+	for i, r := range runes {
+		cells[i] = Cell{Rune: r, Style: style}
+	}
+
+	s.setCells(x, y, cells)
 }
 
 // SetString writes a string at the given position.
@@ -83,15 +124,7 @@ func (s *SubBuffer) SetString(x, y int, str string, style lipgloss.Style) {
 		return
 	}
 
-	runes := []rune(str)
-
-	// Build cells slice
-	cells := make([]Cell, len(runes))
-	for i, r := range runes {
-		cells[i] = Cell{Rune: r, Style: style}
-	}
-
-	s.SetCells(x, y, cells)
+	s.setString(x, y, str, style)
 }
 
 // SetStringTruncated writes a string, truncating with ellipsis if needed.
@@ -109,7 +142,11 @@ func (s *SubBuffer) SetStringTruncated(x, y int, str string, maxWidth int, style
 		}
 	}
 
-	s.SetString(x, y, string(runes), style)
+	if len(runes) == 0 {
+		return
+	}
+
+	s.setString(x, y, string(runes), style)
 }
 
 // Fill fills a rectangular region.
@@ -125,8 +162,9 @@ func (s *SubBuffer) Fill(rect Rect, cell Cell) {
 		row[i] = cell
 	}
 
+	// After clipping, all coordinates are known to be valid
 	for y := clipped.Y; y < clipped.Y+clipped.Height; y++ {
-		s.SetCells(clipped.X, y, row)
+		s.setCells(clipped.X, y, row)
 	}
 }
 
@@ -178,10 +216,14 @@ func (s *SubBuffer) InvertRow(row int) {
 	if row < 0 || row >= s.offset.Height {
 		return
 	}
+	if s.offset.Width == 0 {
+		return
+	}
 	cells := make([]Cell, s.offset.Width)
 	for x := 0; x < s.offset.Width; x++ {
 		cells[x] = s.GetCell(x, row)
 		cells[x].Style = cells[x].Style.Reverse(true)
 	}
-	s.SetCells(0, row, cells)
+	// After validation, row and cells are known to be valid
+	s.setCells(0, row, cells)
 }


### PR DESCRIPTION
Extract internal lowercase methods (setCells, setString) that skip validation for use by internal callers that have already validated their arguments. Public methods (SetCells, SetString) validate then delegate to the internal methods.

Updated internal callers:
- Buffer: SetStringTruncated
- SubBuffer: SetStringTruncated, Fill, InvertRow
- border.go: RenderBorder corners and vertical edges
- stack.go: Modal.Render dim background loop