### PR TITLE
Move dimming code into ModalDialog component

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -510,52 +510,9 @@ func (d *Delegate) View(baseView string) string {
 	// Debug: log compositor output
 	logger.Info("View: size=%dx%d, view len=%d, lines=%d", width, height, len(view), len(strings.Split(view, "\n")))
 
-	// Overlay comment editor if active
+	// Overlay comment editor if active (dimming is handled by ModalDialog)
 	if d.commentEditor.IsActive() {
-		editorBuf := teapot.NewBuffer(d.commentEditor.Width(), d.commentEditor.Height())
-		editorSub := teapot.NewSubBuffer(editorBuf, editorBuf.Bounds())
-		d.commentEditor.Render(editorSub)
-		editorView := editorBuf.RenderToString()
-		editorLines := strings.Split(editorView, "\n")
-
-		leftPadding := width * 10 / 100
-		lines := strings.Split(view, "\n")
-		startLine := (len(lines) - len(editorLines)) / 2
-		if startLine < 0 {
-			startLine = 0
-		}
-		endLine := startLine + len(editorLines)
-
-		// Style for dimming underlying content
-		dimStyle := lipgloss.NewStyle().Faint(true)
-
-		// Dim all lines, overlaying the editor in the middle
-		for lineIdx := 0; lineIdx < len(lines); lineIdx++ {
-			originalLine := lines[lineIdx]
-
-			// Check if this line is within the editor area
-			if lineIdx >= startLine && lineIdx < endLine {
-				editorLineIdx := lineIdx - startLine
-				editorLine := editorLines[editorLineIdx]
-				editorWidth := lipgloss.Width(editorLine)
-
-				// Extract left portion of original line (dimmed)
-				leftPart := extractVisibleChars(originalLine, 0, leftPadding)
-				dimmedLeft := dimStyle.Render(leftPart)
-
-				// Extract right portion of original line (dimmed)
-				rightStart := leftPadding + editorWidth
-				rightPart := extractVisibleChars(originalLine, rightStart, width-rightStart)
-				dimmedRight := dimStyle.Render(rightPart)
-
-				lines[lineIdx] = dimmedLeft + editorLine + dimmedRight
-			} else {
-				// Lines outside the editor area - just dim them
-				dimmedLine := extractVisibleChars(originalLine, 0, width)
-				lines[lineIdx] = dimStyle.Render(dimmedLine)
-			}
-		}
-		return strings.Join(lines, "\n")
+		return d.commentEditor.RenderOverlay(view, width, height)
 	}
 
 	// Overlay help screen if showing
@@ -675,31 +632,6 @@ func resolveBase(base string) (string, error) {
 	}
 
 	return mergeBase, nil
-}
-
-// extractVisibleChars extracts visible characters from a string with ANSI codes.
-// It returns characters from position start to start+length (by visible position).
-func extractVisibleChars(s string, start, length int) string {
-	if length <= 0 {
-		return ""
-	}
-
-	// Parse the ANSI line to get cells
-	cells := teapot.ParseANSILine(s)
-
-	// Extract the requested range
-	var result strings.Builder
-	for i := start; i < start+length; i++ {
-		if i < len(cells) {
-			if cells[i].Rune != 0 {
-				result.WriteRune(cells[i].Rune)
-			}
-		} else {
-			result.WriteRune(' ') // Pad with spaces if line is shorter
-		}
-	}
-
-	return result.String()
 }
 
 // renderError renders an error message

--- a/internal/tui/commenteditor.go
+++ b/internal/tui/commenteditor.go
@@ -625,12 +625,31 @@ func (m *CommentEditor) Render(buf *pot.SubBuffer) {
 	}
 
 	// Sync textarea state to widget
-	if content, ok := m.ModalDialog.Content().(*commentEditorContent); ok {
-		content.textarea = m.textarea
-	}
+	m.syncTextareaState()
 
 	// Render the dialog using RenderWidget for proper border handling
 	pot.RenderWidget(m.ModalDialog, buf)
+}
+
+// RenderOverlay renders the comment editor as an overlay on top of the base view
+// with the background dimmed. This is the standard way to display the editor.
+func (m *CommentEditor) RenderOverlay(baseView string, screenWidth, screenHeight int) string {
+	if !m.active {
+		return baseView
+	}
+
+	// Sync textarea state to widget
+	m.syncTextareaState()
+
+	// Use the ModalDialog's RenderOverlay for dimming and centering
+	return m.ModalDialog.RenderOverlay(baseView, screenWidth, screenHeight)
+}
+
+// syncTextareaState syncs the textarea state to the content widget
+func (m *CommentEditor) syncTextareaState() {
+	if content, ok := m.ModalDialog.Content().(*commentEditorContent); ok {
+		content.textarea = m.textarea
+	}
 }
 
 // ActivateWithConversation activates the comment editor with a full conversation

--- a/teapot/dialog.go
+++ b/teapot/dialog.go
@@ -1,6 +1,8 @@
 package teapot
 
 import (
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -209,4 +211,90 @@ func (d *ModalDialog) SetButtonStyle(style lipgloss.Style) {
 // SetButtonHintStyle sets the button hint style (for Enter/Esc).
 func (d *ModalDialog) SetButtonHintStyle(style lipgloss.Style) {
 	d.buttonHintStyle = style
+}
+
+// RenderOverlay renders the modal dialog centered over a base view with the background dimmed.
+// This is the standard way to display a modal dialog - it handles dimming automatically.
+// The baseView is the underlying content that will be dimmed, and screenWidth/screenHeight
+// are the dimensions of the full screen.
+func (d *ModalDialog) RenderOverlay(baseView string, screenWidth, screenHeight int) string {
+	// Render the dialog to its own buffer
+	dialogBuf := NewBuffer(d.bounds.Width, d.bounds.Height)
+	dialogSub := NewSubBuffer(dialogBuf, dialogBuf.Bounds())
+	RenderWidget(d, dialogSub)
+	dialogView := dialogBuf.RenderToString()
+	dialogLines := strings.Split(dialogView, "\n")
+
+	// Calculate horizontal padding for centering
+	leftPadding := (screenWidth - d.bounds.Width) / 2
+	if leftPadding < 0 {
+		leftPadding = 0
+	}
+
+	// Split base view into lines
+	lines := strings.Split(baseView, "\n")
+
+	// Calculate vertical centering
+	startLine := (len(lines) - len(dialogLines)) / 2
+	if startLine < 0 {
+		startLine = 0
+	}
+	endLine := startLine + len(dialogLines)
+
+	// Style for dimming underlying content
+	dimStyle := lipgloss.NewStyle().Faint(true)
+
+	// Process each line: dim everything, overlay the dialog in the middle
+	for lineIdx := 0; lineIdx < len(lines); lineIdx++ {
+		originalLine := lines[lineIdx]
+
+		// Check if this line is within the dialog area
+		if lineIdx >= startLine && lineIdx < endLine {
+			dialogLineIdx := lineIdx - startLine
+			dialogLine := dialogLines[dialogLineIdx]
+			dialogWidth := lipgloss.Width(dialogLine)
+
+			// Extract left portion of original line (dimmed)
+			leftPart := extractVisibleCharsForOverlay(originalLine, 0, leftPadding)
+			dimmedLeft := dimStyle.Render(leftPart)
+
+			// Extract right portion of original line (dimmed)
+			rightStart := leftPadding + dialogWidth
+			rightPart := extractVisibleCharsForOverlay(originalLine, rightStart, screenWidth-rightStart)
+			dimmedRight := dimStyle.Render(rightPart)
+
+			lines[lineIdx] = dimmedLeft + dialogLine + dimmedRight
+		} else {
+			// Lines outside the dialog area - just dim them
+			dimmedLine := extractVisibleCharsForOverlay(originalLine, 0, screenWidth)
+			lines[lineIdx] = dimStyle.Render(dimmedLine)
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// extractVisibleCharsForOverlay extracts visible characters from a string with ANSI codes.
+// It returns characters from position start to start+length (by visible position).
+func extractVisibleCharsForOverlay(s string, start, length int) string {
+	if length <= 0 {
+		return ""
+	}
+
+	// Parse the ANSI line to get cells
+	cells := ParseANSILine(s)
+
+	// Extract the requested range
+	var result strings.Builder
+	for i := start; i < start+length; i++ {
+		if i < len(cells) {
+			if cells[i].Rune != 0 {
+				result.WriteRune(cells[i].Rune)
+			}
+		} else {
+			result.WriteRune(' ') // Pad with spaces if line is shorter
+		}
+	}
+
+	return result.String()
 }


### PR DESCRIPTION
The screen dimming is now handled automatically by ModalDialog via its RenderOverlay method, which dims the background and centers the dialog. This ensures consistent behavior whenever a modal dialog is displayed.

- Add RenderOverlay method to ModalDialog that handles dimming
- Add RenderOverlay method to CommentEditor that forwards to ModalDialog
- Remove inline dimming code from app.go View method
- Clean up unused extractVisibleChars function from app.go