### PR TITLE
Fix diff view rendering for large hunks

### DIFF
--- a/internal/tui/diffview_subviews.go
+++ b/internal/tui/diffview_subviews.go
@@ -87,20 +87,33 @@ func (w *HunkView) Hunk() *ctypes.Hunk {
 
 // Render renders the hunk to the buffer.
 func (w *HunkView) Render(buf *teapot.SubBuffer) {
+	w.RenderWithYOffset(buf, 0)
+}
+
+// RenderWithYOffset renders the hunk with an optional Y offset for partial visibility.
+// ySkip specifies how many lines at the top to skip (used when the hunk is scrolled
+// and its top portion is above the visible area).
+func (w *HunkView) RenderWithYOffset(buf *teapot.SubBuffer, ySkip int) {
 	width := buf.Width()
 	if width <= 0 {
 		return
 	}
 
+	// y tracks our position in the hunk's logical coordinate space
+	// renderY tracks where we actually render in the buffer
 	y := 0
+	renderY := y - ySkip
 
 	// Render hunk header
 	header := fmt.Sprintf("@@ -%d,%d +%d,%d @@", w.hunk.OldStart, w.hunk.OldLines, w.hunk.NewStart, w.hunk.NewLines)
 	if w.hunk.Header != "" {
 		header += " " + w.hunk.Header
 	}
-	w.renderHeaderLine(buf, y, header, width)
+	if renderY >= 0 {
+		w.renderHeaderLine(buf, renderY, header, width)
+	}
 	y++
+	renderY = y - ySkip
 
 	// Render each line and its comment (if any)
 	// Note: Selection highlighting is done via buffer overlay, not here
@@ -109,8 +122,11 @@ func (w *HunkView) Render(buf *teapot.SubBuffer) {
 		highlighted := w.getHighlightedContent(line)
 
 		// Render the diff line
-		w.renderDiffLine(buf, y, line, highlighted, width)
+		if renderY >= 0 {
+			w.renderDiffLine(buf, renderY, line, highlighted, width)
+		}
 		y++
+		renderY = y - ySkip
 
 		// Render comment if exists
 		if line.NewNum > 0 {
@@ -118,8 +134,11 @@ func (w *HunkView) Render(buf *teapot.SubBuffer) {
 				commentHeight := calculateCommentHeight(conv)
 				// Check if any row in comment is selected (for hotkey display)
 				commentSelected := w.selectedRow >= y && w.selectedRow < y+commentHeight
-				w.renderComment(buf, y, conv, width, commentHeight, commentSelected)
+				if renderY >= 0 || renderY+commentHeight > 0 {
+					w.renderCommentWithYOffset(buf, renderY, conv, width, commentHeight, commentSelected, ySkip-y)
+				}
 				y += commentHeight
+				renderY = y - ySkip
 			}
 		}
 	}
@@ -335,6 +354,146 @@ func (w *HunkView) renderComment(buf *teapot.SubBuffer, startY int, conv *critic
 			bottomLine += strings.Repeat("-", width-len(bottomLine))
 		}
 		buf.SetString(0, y, bottomLine, separatorStyle)
+	}
+}
+
+// renderCommentWithYOffset renders an inline comment with a Y offset for partial visibility.
+// ySkip specifies how many lines at the top of the comment to skip.
+func (w *HunkView) renderCommentWithYOffset(buf *teapot.SubBuffer, startY int, conv *critic.Conversation, width, height int, selected bool, ySkip int) {
+	if ySkip <= 0 {
+		// No offset needed, use regular render
+		w.renderComment(buf, startY, conv, width, height, selected)
+		return
+	}
+
+	if startY >= buf.Height() {
+		return
+	}
+
+	// Styles
+	lightBlueBg := lipgloss.Color("#6B95D8")
+	blackFg := lipgloss.Color("0")
+	grayFg := lipgloss.Color("240")
+
+	contentStyle := lipgloss.NewStyle().Background(lightBlueBg).Foreground(blackFg)
+	separatorStyle := lipgloss.NewStyle().Foreground(grayFg)
+
+	// Track logical Y position and render Y position
+	logicalY := 0
+	renderY := startY
+
+	// Top separator with animation (skip if ySkip > 0)
+	if logicalY >= ySkip && renderY >= 0 && renderY < buf.Height() {
+		// Render the animation frame (first 12 chars)
+		animFrame := GetSeparatorFrame()
+		animCells := teapot.ParseANSILine(animFrame)
+		if len(animCells) > width {
+			animCells = animCells[:width]
+		}
+		buf.SetCells(0, renderY, animCells)
+
+		// Render the rest of the separator (space + dashes)
+		if width > 12 {
+			buf.SetString(12, renderY, " ", separatorStyle)
+		}
+		if width > 13 {
+			buf.SetString(13, renderY, strings.Repeat("-", width-13), separatorStyle)
+		}
+		renderY++
+	} else if logicalY < ySkip {
+		// Skip this line but still advance render position if we're past the skip
+		if logicalY >= ySkip {
+			renderY++
+		}
+	}
+	logicalY++
+
+	// Build content lines
+	var contentLines []string
+	for i, msg := range conv.Messages {
+		prefix := "You"
+		if msg.Author == critic.AuthorAI {
+			prefix = "AI"
+		}
+
+		if i == 0 && msg.Author == critic.AuthorHuman {
+			msgLines := strings.Split(msg.Message, "\n")
+			for _, line := range msgLines {
+				contentLines = append(contentLines, renderMarkdown(line))
+			}
+		} else {
+			replyLines := strings.Split(msg.Message, "\n")
+			for j, line := range replyLines {
+				if j == 0 {
+					contentLines = append(contentLines, fmt.Sprintf("%s: %s", prefix, renderMarkdown(line)))
+				} else {
+					indent := strings.Repeat(" ", len(prefix)+2)
+					contentLines = append(contentLines, indent+renderMarkdown(line))
+				}
+			}
+		}
+	}
+
+	// Prepend resolved status
+	if conv.Status == critic.StatusResolved && len(contentLines) > 0 {
+		contentLines[0] = "(Resolved) " + contentLines[0]
+	}
+
+	// Render content lines
+	for _, line := range contentLines {
+		if logicalY >= ySkip && renderY >= 0 && renderY < buf.Height() {
+			content := " " + line
+			parsedCells := teapot.ParseANSILine(content)
+
+			// Build row of cells with padding
+			rowCells := make([]teapot.Cell, width)
+			for x := 0; x < width; x++ {
+				if x < len(parsedCells) {
+					rowCells[x] = parsedCells[x]
+					rowCells[x].Style = rowCells[x].Style.Background(lightBlueBg).Foreground(blackFg)
+				} else {
+					rowCells[x] = teapot.Cell{Rune: ' ', Style: contentStyle}
+				}
+			}
+			buf.SetCells(0, renderY, rowCells)
+			renderY++
+		} else if logicalY >= ySkip {
+			renderY++
+		}
+		logicalY++
+	}
+
+	// Bottom separator with hotkeys if selected
+	if logicalY >= ySkip && renderY >= 0 && renderY < buf.Height() {
+		var separatorText string
+		if selected {
+			separatorText = "[R]esolve - [Enter] reply"
+			if conv.Status == critic.StatusResolved {
+				separatorText = "[R] unresolve - [Enter] reply"
+			}
+		}
+
+		var bottomLine string
+		if separatorText == "" {
+			bottomLine = strings.Repeat("-", width)
+		} else {
+			textLen := len(separatorText)
+			leftDashes := (width - textLen - 2) / 2
+			rightDashes := width - textLen - 2 - leftDashes
+			if leftDashes < 0 {
+				leftDashes = 0
+			}
+			if rightDashes < 0 {
+				rightDashes = 0
+			}
+			bottomLine = strings.Repeat("-", leftDashes) + " " + separatorText + " " + strings.Repeat("-", rightDashes)
+		}
+
+		// Pad to width if needed
+		if len(bottomLine) < width {
+			bottomLine += strings.Repeat("-", width-len(bottomLine))
+		}
+		buf.SetString(0, renderY, bottomLine, separatorStyle)
 	}
 }
 
@@ -555,16 +714,32 @@ func (w *DiffContentView) Render(buf *teapot.SubBuffer) {
 		}
 		hw.SetSelectedRow(localSelectedRow)
 
-		// Render if any part is visible
-		if renderY+hunkHeight > 0 && renderY < height {
-			hunkBuf := buf.Sub(teapot.NewRect(0, renderY, width, hunkHeight))
-			hw.Render(hunkBuf)
+		// Render if any part is visible (must be visible below the header at y=2)
+		if renderY+hunkHeight > 2 && renderY < height {
+			// Calculate how much of the hunk is above the content area (below header)
+			ySkip := 0
+			startY := renderY
+			if renderY < 2 {
+				ySkip = 2 - renderY
+				startY = 2
+			}
+
+			// Calculate visible height
+			visibleHeight := hunkHeight - ySkip
+			if startY+visibleHeight > height {
+				visibleHeight = height - startY
+			}
+
+			if visibleHeight > 0 {
+				hunkBuf := buf.Sub(teapot.NewRect(0, startY, width, visibleHeight))
+				hw.RenderWithYOffset(hunkBuf, ySkip)
+			}
 		}
 		renderY += hunkHeight
 
 		// Spacing between hunks
 		if hunkIdx < len(w.hunks)-1 {
-			if renderY >= 0 && renderY < height {
+			if renderY >= 2 && renderY < height {
 				emptyStyle := lipgloss.NewStyle()
 				buf.SetString(0, renderY, strings.Repeat(" ", width), emptyStyle)
 			}


### PR DESCRIPTION
When scrolling a diff that exceeds the terminal height, the previous implementation would create SubBuffers with negative Y coordinates, which caused:
1. The hunk content to overwrite the file header (rows 0-1)
2. The wrong portion of the hunk to be displayed (showing from line 0 instead of the scrolled position)

This fix:
- Creates hunk SubBuffers starting at y=2 (after file header) when renderY < 2 to avoid overlapping the header
- Adds RenderWithYOffset method to HunkView that skips lines that are above the visible area
- Adds renderCommentWithYOffset method for partial comment rendering
- Properly calculates visible height to avoid rendering off-screen