### PR TITLE
Integrate viewport component into ScrollView

### DIFF
--- a/docs/agents/logs/20260121-031648-integrate-viewport-scrollview.md
+++ b/docs/agents/logs/20260121-031648-integrate-viewport-scrollview.md
@@ -1,0 +1,38 @@
+# Task: Integrate bubbles viewport into ScrollView
+
+**Started:** 2026-01-21 03:16:48
+**Ended:** 2026-01-21 03:21:50
+**Strategy:** Refactoring
+**Status:** Completed
+**Complexity:** Simple
+**Used Models:** Opus
+
+## Objective
+Replace custom scrolling logic in ScrollView with charmbracelet/bubbles viewport component while maintaining non-scrolling header and footer widgets.
+
+## Progress
+- [x] Analyzed current ScrollView implementation
+- [x] Reviewed bubbles viewport API
+- [x] Designed integration approach
+- [x] Implement viewport integration in ScrollView
+- [x] Update keyboard handling to use viewport methods
+- [x] Add mouse wheel support
+- [x] Build and test
+
+## Obstacles
+- **Issue:** Integration test TestLineDisplacement fails
+  **Resolution:** Confirmed this is a pre-existing issue unrelated to our changes (fails both with and without the changes)
+
+## Outcome
+Successfully integrated charmbracelet/bubbles viewport into ScrollView:
+- Viewport model manages scroll state and content
+- Header/footer views render separately (non-scrolling)
+- Children are pre-rendered to strings and fed to viewport
+- Keyboard handling uses viewport's LineUp/LineDown/HalfViewUp/HalfViewDown/GotoTop/GotoBottom methods
+- Added mouse wheel support via HandleMouse method
+- All teapot tests pass
+
+## Learnings
+- The bubbles viewport works with string content (lines with ANSI codes), requiring pre-rendering of Views
+- ParseANSILine can convert viewport output back to cells for buffer rendering
+- Viewport provides clean scrolling primitives that simplify the implementation

--- a/teapot/scroll_view.go
+++ b/teapot/scroll_view.go
@@ -1,29 +1,41 @@
 package teapot
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+)
 
 // ScrollView is a container that scrolls multiple children vertically.
 // Children are laid out one after another, and the view can be scrolled
 // to show different portions of the content.
 // Optionally supports fixed header and footer views that don't scroll.
-// Scrolling: up/down (line), ctrl+up/ctrl+down/space (page), home/end (bounds).
+// Uses charmbracelet/bubbles viewport for scrolling functionality.
 type ScrollView struct {
 	BaseView
 	children      []View
 	headerView    View // Optional fixed header (doesn't scroll)
 	footerView    View // Optional fixed footer (doesn't scroll)
-	scrollOffset  int
-	contentHeight int // Total height of all children
+	viewport      viewport.Model
+	contentHeight int    // Total height of all children
+	contentCache  string // Cached pre-rendered content for viewport
+	contentDirty  bool   // True if content needs re-rendering
 }
 
 // NewScrollView creates a new vertical scroll view with the given children.
 // Children are laid out vertically, with the first child at the top.
 func NewScrollView(children ...View) *ScrollView {
 	sv := &ScrollView{
-		BaseView: NewBaseView(),
-		children: make([]View, 0, len(children)),
+		BaseView:     NewBaseView(),
+		children:     make([]View, 0, len(children)),
+		viewport:     viewport.New(0, 0),
+		contentDirty: true,
 	}
 	sv.SetFocusable(true)
+
+	// Enable mouse wheel support
+	sv.viewport.MouseWheelEnabled = true
 
 	for _, child := range children {
 		sv.AddChild(child)
@@ -36,6 +48,7 @@ func NewScrollView(children ...View) *ScrollView {
 func (s *ScrollView) AddChild(child View) {
 	child.SetParent(s)
 	s.children = append(s.children, child)
+	s.contentDirty = true
 	s.layoutChildren()
 }
 
@@ -45,8 +58,11 @@ func (s *ScrollView) ClearChildren() {
 		child.SetParent(nil)
 	}
 	s.children = s.children[:0]
-	s.scrollOffset = 0
 	s.contentHeight = 0
+	s.contentDirty = true
+	s.contentCache = ""
+	s.viewport.SetContent("")
+	s.viewport.GotoTop()
 }
 
 // Children returns the scroll view's children.
@@ -64,6 +80,7 @@ func (s *ScrollView) SetHeaderView(header View) {
 	if header != nil {
 		header.SetParent(s)
 	}
+	s.contentDirty = true
 	s.layoutChildren()
 }
 
@@ -77,6 +94,7 @@ func (s *ScrollView) SetFooterView(footer View) {
 	if footer != nil {
 		footer.SetParent(s)
 	}
+	s.contentDirty = true
 	s.layoutChildren()
 }
 
@@ -132,7 +150,7 @@ func (s *ScrollView) SetBounds(bounds Rect) {
 }
 
 // layoutChildren lays out all children vertically and calculates total content height.
-// Also lays out header and footer views if present.
+// Also lays out header and footer views if present, and updates viewport dimensions.
 func (s *ScrollView) layoutChildren() {
 	width := s.bounds.Width
 
@@ -154,9 +172,18 @@ func (s *ScrollView) layoutChildren() {
 		})
 	}
 
+	// Update viewport dimensions for the scrollable area
+	scrollHeight := s.scrollableHeight()
+	if scrollHeight < 0 {
+		scrollHeight = 0
+	}
+	s.viewport.Width = width
+	s.viewport.Height = scrollHeight
+
 	// Layout scrollable children
 	if len(s.children) == 0 {
 		s.contentHeight = 0
+		s.contentDirty = true
 		return
 	}
 
@@ -182,48 +209,27 @@ func (s *ScrollView) layoutChildren() {
 	}
 
 	s.contentHeight = y
-	s.clampScrollOffset()
-}
-
-// clampScrollOffset ensures scroll offset is within valid bounds.
-func (s *ScrollView) clampScrollOffset() {
-	maxScroll := s.maxScrollOffset()
-	if s.scrollOffset < 0 {
-		s.scrollOffset = 0
-	}
-	if s.scrollOffset > maxScroll {
-		s.scrollOffset = maxScroll
-	}
-}
-
-// maxScrollOffset returns the maximum valid scroll offset.
-func (s *ScrollView) maxScrollOffset() int {
-	maxScroll := s.contentHeight - s.scrollableHeight()
-	if maxScroll < 0 {
-		return 0
-	}
-	return maxScroll
+	s.contentDirty = true
 }
 
 // ScrollOffset returns the current scroll offset.
 func (s *ScrollView) ScrollOffset() int {
-	return s.scrollOffset
+	return s.viewport.YOffset
 }
 
 // SetScrollOffset sets the scroll offset.
 func (s *ScrollView) SetScrollOffset(offset int) {
-	s.scrollOffset = offset
-	s.clampScrollOffset()
+	s.viewport.SetYOffset(offset)
 }
 
 // ScrollToTop scrolls to the top of the content.
 func (s *ScrollView) ScrollToTop() {
-	s.scrollOffset = 0
+	s.viewport.GotoTop()
 }
 
 // ScrollToBottom scrolls to the bottom of the content.
 func (s *ScrollView) ScrollToBottom() {
-	s.scrollOffset = s.maxScrollOffset()
+	s.viewport.GotoBottom()
 }
 
 // Render renders the visible portion of the scroll view's content.
@@ -268,114 +274,124 @@ func (s *ScrollView) Render(buf *SubBuffer) {
 		return
 	}
 
-	// Render each child that is at least partially visible
-	for _, child := range s.children {
-		childBounds := child.Bounds()
+	// Update viewport content if dirty
+	if s.contentDirty {
+		s.updateViewportContent()
+	}
 
-		// Calculate child's position relative to scroll offset
-		childTop := childBounds.Y - s.scrollOffset
-		childBottom := childTop + childBounds.Height
+	// Get the visible content from viewport and render it
+	viewportContent := s.viewport.View()
+	lines := strings.Split(viewportContent, "\n")
 
-		// Skip if completely above or below the scrollable area
-		if childBottom <= 0 || childTop >= scrollHeight {
-			continue
+	for y, line := range lines {
+		if y >= scrollHeight {
+			break
+		}
+		// Parse the ANSI line back to cells
+		cells := ParseANSILine(line)
+
+		// Pad to full width if needed
+		if len(cells) < viewWidth {
+			padding := make([]Cell, viewWidth-len(cells))
+			for i := range padding {
+				padding[i] = EmptyCell
+			}
+			cells = append(cells, padding...)
+		} else if len(cells) > viewWidth {
+			cells = cells[:viewWidth]
 		}
 
-		// Calculate the visible portion of the child
-		visibleTop := max(0, childTop)
-		visibleBottom := min(scrollHeight, childBottom)
-		visibleHeight := visibleBottom - visibleTop
-
-		// Calculate offset within the child (for partial visibility at top)
-		childYOffset := 0
-		if childTop < 0 {
-			childYOffset = -childTop
-		}
-
-		// Create a sub-buffer for the visible portion (offset by header height)
-		childSub := NewSubBuffer(buf.parent, Rect{
-			Position: Position{
-				X: buf.offset.X,
-				Y: buf.offset.Y + hHeight + visibleTop,
-			},
-			Size: Size{
-				Width:  viewWidth,
-				Height: visibleHeight,
-			},
-		})
-
-		// Render the child with adjusted bounds for partial visibility
-		if childYOffset > 0 || visibleHeight < childBounds.Height {
-			// Child is partially visible - we need to render it offset
-			s.renderChildPartial(child, childSub, childYOffset, visibleHeight)
-		} else {
-			// Child is fully visible
-			RenderWidget(child, childSub)
-		}
+		// Write to buffer at the correct Y position (offset by header)
+		buf.SetCells(0, hHeight+y, cells)
 	}
 }
 
-// renderChildPartial renders a portion of a child starting at yOffset.
-func (s *ScrollView) renderChildPartial(child View, buf *SubBuffer, yOffset, height int) {
-	// Create a temporary buffer for the full child render
-	childBounds := child.Bounds()
-	tempBuf := NewBuffer(childBounds.Width, childBounds.Height)
-	tempSubBuf := NewSubBuffer(tempBuf, Rect{
-		Position: Position{X: 0, Y: 0},
-		Size:     Size{Width: childBounds.Width, Height: childBounds.Height},
-	})
-
-	// Render child to temp buffer
-	RenderWidget(child, tempSubBuf)
-
-	// Copy the visible portion to the output buffer
-	width := min(buf.Width(), tempBuf.Width())
-	for y := 0; y < height; y++ {
-		srcY := yOffset + y
-		if srcY >= tempBuf.Height() {
-			break
-		}
-		// Get the row from temp buffer and set it in the output buffer
-		rowCells := make([]Cell, width)
-		for x := 0; x < width; x++ {
-			rowCells[x] = tempBuf.GetCell(x, srcY)
-		}
-		buf.SetCells(0, y, rowCells)
+// updateViewportContent pre-renders all children to a string and updates the viewport.
+func (s *ScrollView) updateViewportContent() {
+	if len(s.children) == 0 {
+		s.contentCache = ""
+		s.viewport.SetContent("")
+		s.contentDirty = false
+		return
 	}
+
+	width := s.bounds.Width
+	if width <= 0 {
+		s.contentCache = ""
+		s.viewport.SetContent("")
+		s.contentDirty = false
+		return
+	}
+
+	// Create a buffer for all children content
+	contentBuf := NewBuffer(width, s.contentHeight)
+
+	// Render each child to the content buffer
+	for _, child := range s.children {
+		childBounds := child.Bounds()
+		childSub := NewSubBuffer(contentBuf, Rect{
+			Position: Position{X: 0, Y: childBounds.Y},
+			Size:     Size{Width: width, Height: childBounds.Height},
+		})
+		RenderWidget(child, childSub)
+	}
+
+	// Convert buffer to string for viewport
+	s.contentCache = contentBuf.RenderToString()
+	s.viewport.SetContent(s.contentCache)
+	s.contentDirty = false
 }
 
 // HandleKey handles keyboard input for scrolling.
+// Uses viewport's built-in scrolling methods.
 func (s *ScrollView) HandleKey(msg tea.KeyMsg) (bool, tea.Cmd) {
-	viewHeight := s.scrollableHeight()
-	pageSize := viewHeight - 3
-	if pageSize < 1 {
-		pageSize = 1
-	}
-
 	switch msg.String() {
 	case "up":
-		if s.scrollOffset > 0 {
-			s.scrollOffset--
+		if !s.viewport.AtTop() {
+			s.viewport.LineUp(1)
 			return true, nil
 		}
 	case "down":
-		if s.scrollOffset < s.maxScrollOffset() {
-			s.scrollOffset++
+		if !s.viewport.AtBottom() {
+			s.viewport.LineDown(1)
 			return true, nil
 		}
-	case "ctrl+up":
-		s.scrollOffset -= pageSize
-		s.clampScrollOffset()
+	case "ctrl+up", "pgup":
+		s.viewport.HalfViewUp()
 		return true, nil
-	case "ctrl+down", " ": // space for page down
-		s.scrollOffset += pageSize
-		s.clampScrollOffset()
+	case "ctrl+down", "pgdown", " ": // space for page down
+		s.viewport.HalfViewDown()
 		return true, nil
 	case "home":
-		s.ScrollToTop()
+		s.viewport.GotoTop()
 		return true, nil
 	case "end":
-		s.ScrollToBottom()
+		s.viewport.GotoBottom()
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// HandleMouse handles mouse input for scrolling.
+// Passes mouse wheel events to the viewport for scroll handling.
+func (s *ScrollView) HandleMouse(msg tea.MouseMsg) (bool, tea.Cmd) {
+	// Only handle mouse wheel events within the scrollable area
+	hHeight := s.headerHeight()
+	fHeight := s.footerHeight()
+
+	// Check if mouse is in the scrollable area
+	if msg.Y < hHeight || msg.Y >= s.bounds.Height-fHeight {
+		return false, nil
+	}
+
+	// Handle mouse wheel scrolling
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		s.viewport.LineUp(3)
+		return true, nil
+	case tea.MouseButtonWheelDown:
+		s.viewport.LineDown(3)
 		return true, nil
 	}
 


### PR DESCRIPTION
Replace custom scrolling logic with charmbracelet/bubbles viewport:
- Use viewport.Model for scroll state and content management
- Pre-render children to strings for viewport consumption
- Keep non-scrolling header/footer Views separate
- Add mouse wheel support via HandleMouse
- Use viewport's LineUp/LineDown/HalfViewUp/HalfViewDown methods