### PR TITLE
Add JSON schema validation to observable

### DIFF
--- a/docs/agents/logs/20260121-035856-add-json-schema-validation.md
+++ b/docs/agents/logs/20260121-035856-add-json-schema-validation.md
@@ -1,0 +1,55 @@
+# Task: Add JSON Schema Validation to Observable
+
+**Started:** 2026-01-21 03:58:56
+**Ended:** 2026-01-21 04:02:00
+**Strategy:** Feature (TDD)
+**Status:** Completed
+**Complexity:** Medium
+**Used Models:** Opus
+
+## Objective
+Add JSON schema validation support to the Observable package. Allow configuring schemas on specific keys so that when SetValueAtKey is called, the value is validated against the schema if one is configured for that key (or a parent path).
+
+## Progress
+- [x] Explore codebase and understand Observable implementation
+- [x] Research JSON schema validation libraries
+- [x] Design the schema validation API
+- [x] Write failing tests for schema configuration
+- [x] Implement schema storage in Observable
+- [x] Write failing tests for schema validation on SetValueAtKey
+- [x] Implement schema validation in SetValueAtKey
+- [x] Write tests for nested key schema matching
+- [x] Implement nested key schema matching
+- [x] Run all tests and verify (84 tests pass)
+
+## Design Notes
+- Using `santhosh-tekuri/jsonschema/v5` library for JSON schema validation
+- API: `obs.WithSchema(key string, schema string) *Observable` for configuration
+- Validation occurs in SetValueAtKey before changes are applied
+- If validation fails, panic with preconditions.Check (consistent with existing error handling)
+- Schema matching: exact key match or prefix match (e.g., schema on "config" applies to "config.name")
+
+## Obstacles
+None yet.
+
+## Outcome
+Successfully implemented JSON schema validation for the Observable package:
+
+**Files changed:**
+- `simple-go/observable/observable.go` - Added schemas field to struct and validation call in SetValueAtKey
+- `simple-go/observable/schema.go` - New file with WithSchema method and validation logic
+- `simple-go/observable/schema_test.go` - 21 comprehensive tests for schema validation
+- `go.mod` / `go.sum` - Added `github.com/santhosh-tekuri/jsonschema/v5` dependency
+
+**Features:**
+- `WithSchema(key, schema)` method for configuring schemas (chainable)
+- Supports JSON string or `map[string]any` schema format
+- Validates on exact key match
+- Validates child keys against parent schemas (simulates post-change state)
+- Setting `nil` (deletion) always allowed
+- Panics with descriptive error on validation failure (consistent with existing error handling)
+
+## Learnings
+- The preconditions package requires constant format strings, so dynamic error messages need to use `%s` placeholder
+- JSON Schema validation libraries in Go are mature; `santhosh-tekuri/jsonschema/v5` supports draft 2020-12
+- When validating child key changes against parent schemas, need to simulate the post-change state before validation

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/net v0.49.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.52.0 h1:Rvi+3BFHES3A8meP33VPAxiBZX/Aws5RxrschYGjomw=
 github.com/samber/lo v1.52.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/simple-go/observable/observable.go
+++ b/simple-go/observable/observable.go
@@ -33,6 +33,7 @@ type Observable struct {
 	data          any
 	subscriptions map[Subscription]*subscription
 	nextSubID     Subscription
+	schemas       map[string]*schemaEntry
 	mu            sync.RWMutex
 }
 
@@ -204,6 +205,12 @@ func (o *Observable) SetValueAtKey(key string, value any) {
 
 	// Hold lock for state changes
 	o.mu.Lock()
+
+	// Validate against schema before making changes
+	if errMsg := o.validateAgainstSchema(key, value); errMsg != "" {
+		o.mu.Unlock()
+		preconditions.Check(false, "%s", errMsg)
+	}
 
 	// Get old value at the target key
 	oldValue := o.getValueInternal(key)

--- a/simple-go/observable/schema.go
+++ b/simple-go/observable/schema.go
@@ -1,0 +1,189 @@
+package observable
+
+import (
+	"encoding/json"
+	"strings"
+
+	"git.15b.it/eno/critic/simple-go/preconditions"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+// schemaEntry holds a compiled schema and its source for a key.
+type schemaEntry struct {
+	schema *jsonschema.Schema
+	key    string
+}
+
+// WithSchema configures a JSON schema for the specified key.
+// The schema can be a JSON string or a map[string]any.
+// When SetValueAtKey is called on this key (or a child key), the value
+// will be validated against the schema.
+// Panics if the schema is invalid.
+// Returns the Observable for chaining.
+func (o *Observable) WithSchema(key string, schema any) *Observable {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	// Initialize schemas map if needed
+	if o.schemas == nil {
+		o.schemas = make(map[string]*schemaEntry)
+	}
+
+	// Convert schema to JSON bytes
+	var schemaBytes []byte
+	var err error
+
+	switch s := schema.(type) {
+	case string:
+		schemaBytes = []byte(s)
+	case map[string]any:
+		schemaBytes, err = json.Marshal(s)
+		preconditions.Check(err == nil, "failed to marshal schema for key %q: %v", key, err)
+	default:
+		preconditions.Check(false, "schema must be a string or map[string]any, got %T", schema)
+	}
+
+	// Compile the schema
+	compiler := jsonschema.NewCompiler()
+	schemaID := "schema://" + key
+	err = compiler.AddResource(schemaID, strings.NewReader(string(schemaBytes)))
+	preconditions.Check(err == nil, "invalid schema for key %q: %v", key, err)
+
+	compiled, err := compiler.Compile(schemaID)
+	preconditions.Check(err == nil, "failed to compile schema for key %q: %v", key, err)
+
+	o.schemas[key] = &schemaEntry{
+		schema: compiled,
+		key:    key,
+	}
+
+	return o
+}
+
+// validateAgainstSchema checks if the value at the given key is valid according
+// to any applicable schema. Returns an error message if validation fails, or empty string if valid.
+// Must be called with lock held.
+func (o *Observable) validateAgainstSchema(key string, value any) string {
+	if o.schemas == nil || len(o.schemas) == 0 {
+		return ""
+	}
+
+	// Setting to nil (deletion) is always allowed
+	if value == nil {
+		return ""
+	}
+
+	// Check for exact match schema
+	if entry, ok := o.schemas[key]; ok {
+		if err := entry.schema.Validate(value); err != nil {
+			return formatValidationError(key, err)
+		}
+		return ""
+	}
+
+	// Check if there's a parent schema that applies
+	// If we're setting "config.port", check if there's a schema for "config"
+	parts := strings.Split(key, ".")
+	for i := len(parts) - 1; i > 0; i-- {
+		parentKey := strings.Join(parts[:i], ".")
+		if entry, ok := o.schemas[parentKey]; ok {
+			// We need to validate the entire parent object after the change
+			// First, get the current parent value
+			parentValue := o.getValueInternal(parentKey)
+
+			// Simulate what the parent will look like after this change
+			childKey := strings.Join(parts[i:], ".")
+			simulatedParent := simulateNestedSet(parentValue, childKey, value)
+
+			if err := entry.schema.Validate(simulatedParent); err != nil {
+				return formatValidationError(parentKey, err)
+			}
+			return ""
+		}
+	}
+
+	return ""
+}
+
+// simulateNestedSet creates a copy of the parent with the nested value set.
+func simulateNestedSet(parent any, childKey string, value any) any {
+	if parent == nil {
+		parent = make(map[string]any)
+	}
+
+	// Make a shallow copy of the parent
+	var result any
+	switch p := parent.(type) {
+	case map[string]any:
+		result = copyMap(p)
+	case []any:
+		result = copySlice(p)
+	default:
+		// If parent is a primitive, we can't set a child - this will fail validation
+		result = parent
+	}
+
+	// Now set the child value in the copy
+	parts := strings.Split(childKey, ".")
+	setNestedValue(result, parts, value)
+
+	return result
+}
+
+// setNestedValue sets a value in a nested structure, modifying the container in place.
+func setNestedValue(container any, parts []string, value any) {
+	if len(parts) == 0 {
+		return
+	}
+
+	part := parts[0]
+	isLast := len(parts) == 1
+
+	if m, ok := container.(map[string]any); ok {
+		if isLast {
+			m[part] = value
+		} else {
+			if m[part] == nil {
+				// Determine if next part is numeric
+				if _, isNum := parseIndex(parts[1]); isNum {
+					m[part] = make([]any, 0)
+				} else {
+					m[part] = make(map[string]any)
+				}
+			}
+			setNestedValue(m[part], parts[1:], value)
+		}
+	} else if s, ok := container.([]any); ok {
+		if idx, isNum := parseIndex(part); isNum && idx < len(s) {
+			if isLast {
+				s[idx] = value
+			} else {
+				if s[idx] == nil {
+					if _, nextIsNum := parseIndex(parts[1]); nextIsNum {
+						s[idx] = make([]any, 0)
+					} else {
+						s[idx] = make(map[string]any)
+					}
+				}
+				setNestedValue(s[idx], parts[1:], value)
+			}
+		}
+	}
+}
+
+// formatValidationError creates a human-readable error message from a validation error.
+func formatValidationError(key string, err error) string {
+	if validationErr, ok := err.(*jsonschema.ValidationError); ok {
+		// Get the first detailed error
+		causes := validationErr.BasicOutput().Errors
+		if len(causes) > 0 {
+			for _, cause := range causes {
+				if cause.Error != "" {
+					return "schema validation failed for key \"" + key + "\": " + cause.Error
+				}
+			}
+		}
+		return "schema validation failed for key \"" + key + "\": " + validationErr.Error()
+	}
+	return "schema validation failed for key \"" + key + "\": " + err.Error()
+}

--- a/simple-go/observable/schema_test.go
+++ b/simple-go/observable/schema_test.go
@@ -1,0 +1,255 @@
+package observable
+
+import (
+	"testing"
+
+	"git.15b.it/eno/critic/simple-go/assert"
+)
+
+// Tests for JSON schema validation support
+
+func TestWithSchemaReturnsObservable(t *testing.T) {
+	schema := `{"type": "string"}`
+	obs := New().WithSchema("name", schema)
+	assert.NotNil(t, obs, "WithSchema should return non-nil Observable")
+}
+
+func TestWithSchemaChaining(t *testing.T) {
+	obs := New().
+		WithSchema("name", `{"type": "string"}`).
+		WithSchema("age", `{"type": "integer", "minimum": 0}`)
+	assert.NotNil(t, obs, "chained WithSchema should work")
+}
+
+func TestSchemaValidationPassesForValidString(t *testing.T) {
+	obs := New().WithSchema("name", `{"type": "string"}`)
+
+	// Should not panic
+	obs.SetValueAtKey("name", "Alice")
+	assert.Equals(t, obs.GetString("name"), "Alice", "should set valid string")
+}
+
+func TestSchemaValidationPassesForValidNumber(t *testing.T) {
+	obs := New().WithSchema("age", `{"type": "integer", "minimum": 0, "maximum": 150}`)
+
+	obs.SetValueAtKey("age", 30)
+	assert.Equals(t, obs.GetInt("age"), 30, "should set valid integer")
+}
+
+func TestSchemaValidationPassesForValidObject(t *testing.T) {
+	schema := `{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"},
+			"age": {"type": "integer"}
+		},
+		"required": ["name"]
+	}`
+	obs := New().WithSchema("user", schema)
+
+	obs.SetValueAtKey("user", map[string]any{
+		"name": "Alice",
+		"age":  30,
+	})
+	assert.Equals(t, obs.GetValue("user.name"), "Alice", "should set valid object")
+}
+
+func TestSchemaValidationFailsForInvalidType(t *testing.T) {
+	obs := New().WithSchema("name", `{"type": "string"}`)
+
+	defer func() {
+		r := recover()
+		assert.NotNil(t, r, "should panic when setting invalid type")
+	}()
+
+	obs.SetValueAtKey("name", 123) // number instead of string
+}
+
+func TestSchemaValidationFailsForInvalidNumber(t *testing.T) {
+	obs := New().WithSchema("age", `{"type": "integer", "minimum": 0}`)
+
+	defer func() {
+		r := recover()
+		assert.NotNil(t, r, "should panic when setting negative age")
+	}()
+
+	obs.SetValueAtKey("age", -5) // negative number
+}
+
+func TestSchemaValidationFailsForMissingRequired(t *testing.T) {
+	schema := `{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"},
+			"age": {"type": "integer"}
+		},
+		"required": ["name"]
+	}`
+	obs := New().WithSchema("user", schema)
+
+	defer func() {
+		r := recover()
+		assert.NotNil(t, r, "should panic when required field is missing")
+	}()
+
+	obs.SetValueAtKey("user", map[string]any{
+		"age": 30, // missing required "name"
+	})
+}
+
+func TestSchemaValidationForArray(t *testing.T) {
+	schema := `{
+		"type": "array",
+		"items": {"type": "string"}
+	}`
+	obs := New().WithSchema("tags", schema)
+
+	// Valid array of strings
+	obs.SetValueAtKey("tags", []any{"go", "json", "schema"})
+	tags := obs.GetSlice("tags")
+	assert.Equals(t, len(tags), 3, "should have 3 tags")
+}
+
+func TestSchemaValidationFailsForInvalidArrayItem(t *testing.T) {
+	schema := `{
+		"type": "array",
+		"items": {"type": "string"}
+	}`
+	obs := New().WithSchema("tags", schema)
+
+	defer func() {
+		r := recover()
+		assert.NotNil(t, r, "should panic when array contains non-string")
+	}()
+
+	obs.SetValueAtKey("tags", []any{"go", 123, "schema"}) // 123 is not a string
+}
+
+func TestSchemaDoesNotAffectUnrelatedKeys(t *testing.T) {
+	obs := New().WithSchema("name", `{"type": "string"}`)
+
+	// Setting a different key should not be validated
+	obs.SetValueAtKey("count", 42)
+	assert.Equals(t, obs.GetInt("count"), 42, "unrelated key should be set without validation")
+}
+
+func TestSchemaValidationForNestedKey(t *testing.T) {
+	obs := New().WithSchema("config.port", `{"type": "integer", "minimum": 1, "maximum": 65535}`)
+
+	obs.SetValueAtKey("config.port", 8080)
+	assert.Equals(t, obs.GetInt("config.port"), 8080, "should set valid port")
+}
+
+func TestSchemaValidationFailsForInvalidNestedKey(t *testing.T) {
+	obs := New().WithSchema("config.port", `{"type": "integer", "minimum": 1, "maximum": 65535}`)
+
+	defer func() {
+		r := recover()
+		assert.NotNil(t, r, "should panic when port is out of range")
+	}()
+
+	obs.SetValueAtKey("config.port", 99999) // out of range
+}
+
+func TestSchemaOnParentValidatesChildKeys(t *testing.T) {
+	// When a schema is set on "config", setting "config.name" should validate
+	// the entire "config" object after the change
+	schema := `{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"},
+			"port": {"type": "integer"}
+		}
+	}`
+	obs := New().WithSchema("config", schema)
+
+	// First set a valid config
+	obs.SetValueAtKey("config", map[string]any{"name": "server", "port": 8080})
+
+	// Now try to set an invalid child value
+	defer func() {
+		r := recover()
+		assert.NotNil(t, r, "should panic when child value violates parent schema")
+	}()
+
+	obs.SetValueAtKey("config.port", "not-a-number") // string instead of integer
+}
+
+func TestSchemaValidationWithMapSchema(t *testing.T) {
+	// Test that schema can be provided as map[string]any
+	schema := map[string]any{
+		"type":    "string",
+		"pattern": "^[a-z]+$",
+	}
+	obs := New().WithSchema("id", schema)
+
+	obs.SetValueAtKey("id", "abc")
+	assert.Equals(t, obs.GetString("id"), "abc", "should set valid lowercase string")
+}
+
+func TestSchemaValidationWithMapSchemaFails(t *testing.T) {
+	schema := map[string]any{
+		"type":    "string",
+		"pattern": "^[a-z]+$",
+	}
+	obs := New().WithSchema("id", schema)
+
+	defer func() {
+		r := recover()
+		assert.NotNil(t, r, "should panic when pattern doesn't match")
+	}()
+
+	obs.SetValueAtKey("id", "ABC123") // doesn't match pattern
+}
+
+func TestSchemaValidationAllowsNilForOptionalKey(t *testing.T) {
+	obs := New().WithSchema("name", `{"type": "string"}`)
+
+	// Setting to nil (deletion) should be allowed
+	obs.SetValueAtKey("name", "Alice")
+	obs.SetValueAtKey("name", nil)
+	assert.Nil(t, obs.GetValue("name"), "should allow deletion via nil")
+}
+
+func TestSchemaValidationWithBoolean(t *testing.T) {
+	obs := New().WithSchema("enabled", `{"type": "boolean"}`)
+
+	obs.SetValueAtKey("enabled", true)
+	assert.True(t, obs.GetBool("enabled"), "should set boolean")
+}
+
+func TestSchemaValidationFailsForBooleanWithWrongType(t *testing.T) {
+	obs := New().WithSchema("enabled", `{"type": "boolean"}`)
+
+	defer func() {
+		r := recover()
+		assert.NotNil(t, r, "should panic when setting non-boolean")
+	}()
+
+	obs.SetValueAtKey("enabled", "yes") // string instead of boolean
+}
+
+func TestWithSchemaOnNewWithData(t *testing.T) {
+	data := map[string]any{"count": 10}
+	obs := NewWithData(data).WithSchema("count", `{"type": "integer", "minimum": 0}`)
+
+	// Should be able to update with valid value
+	obs.SetValueAtKey("count", 20)
+	assert.Equals(t, obs.GetInt("count"), 20, "should update to valid value")
+}
+
+func TestMultipleSchemasOnDifferentKeys(t *testing.T) {
+	obs := New().
+		WithSchema("name", `{"type": "string"}`).
+		WithSchema("age", `{"type": "integer", "minimum": 0}`).
+		WithSchema("email", `{"type": "string", "format": "email"}`)
+
+	obs.SetValueAtKey("name", "Alice")
+	obs.SetValueAtKey("age", 30)
+	// Note: email format validation may be lenient in some implementations
+	obs.SetValueAtKey("email", "alice@example.com")
+
+	assert.Equals(t, obs.GetString("name"), "Alice", "name should be set")
+	assert.Equals(t, obs.GetInt("age"), 30, "age should be set")
+	assert.Equals(t, obs.GetString("email"), "alice@example.com", "email should be set")
+}


### PR DESCRIPTION
Add the ability to configure JSON schemas on specific keys in an Observable. When SetValueAtKey is called, the value is validated against the schema if one is configured for that key or a parent key.

Features:
- WithSchema(key, schema) method for configuring schemas (chainable)
- Supports JSON string or map[string]any schema format
- Validates on exact key match
- Validates child keys against parent schemas
- Setting nil (deletion) always allowed
- Panics with descriptive error on validation failure

Uses github.com/santhosh-tekuri/jsonschema/v5 for JSON Schema validation.