### PR TITLE
Define JSON schema for SetDiffArgs

### DIFF
--- a/docs/agents/logs/20260121-050428-setdiffargs-json-schema.md
+++ b/docs/agents/logs/20260121-050428-setdiffargs-json-schema.md
@@ -1,0 +1,35 @@
+# Task: Add JSON schema validation to SetDiffArgs
+
+**Started:** 2026-01-21 05:04:28
+**Ended:** 2026-01-21 05:10:00
+**Strategy:** Feature (TDD)
+**Status:** Completed
+**Complexity:** Simple
+**Used Models:** Opus
+
+## Objective
+Define a JSON schema for SetDiffArgs and apply the entire args as a single map, not with individual updates.
+
+## Progress
+- [x] Explore codebase to understand current implementation
+- [x] Read existing schema validation implementation
+- [x] Write test for SetDiffArgs schema validation
+- [x] Define JSON schema for DiffArgs
+- [x] Add WithSchema call during Session initialization
+- [x] Run tests and verify
+- [x] Commit and push changes
+
+## Obstacles
+None.
+
+## Outcome
+Added JSON schema validation for DiffArgs:
+- Defined `DiffArgsSchema` as a map[string]any with proper JSON schema structure
+- Schema validates: bases (array of strings), currentBase (integer >= 0), paths (array of strings), extensions (array of strings)
+- All fields are required
+- Registered schema with `WithSchema` during `NewSession()` initialization
+- Added 3 tests: valid args, invalid currentBase type, invalid bases type
+
+## Learnings
+- The existing Observable.WithSchema API supports both JSON string and map[string]any schema formats
+- Schema validation panics early at SetValueAtKey time, preventing invalid data from entering the system

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -69,6 +69,18 @@ type DiffArgs struct {
 	Extensions  []string `json:"extensions"`  // File extensions to include
 }
 
+// DiffArgsSchema is the JSON schema for validating DiffArgs values
+var DiffArgsSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"bases":       map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+		"currentBase": map[string]any{"type": "integer", "minimum": 0},
+		"paths":       map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+		"extensions":  map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+	},
+	"required": []any{"bases", "currentBase", "paths", "extensions"},
+}
+
 // Selection holds the current selection state
 type Selection struct {
 	FileIndex   int    `json:"fileIndex"`
@@ -102,7 +114,7 @@ type Session struct {
 // NewSession creates a new Session with the given parameters
 func NewSession(gitRoot string, messaging critic.Messaging, args DiffArgs) (*Session, error) {
 	s := &Session{
-		Observable:   observable.New(),
+		Observable:   observable.New().WithSchema(KeyDiffArgs, DiffArgsSchema),
 		messaging:    messaging,
 		gitRoot:      gitRoot,
 		internalSubs: make([]observable.Subscription, 0),

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -525,3 +525,46 @@ func TestStartWatchers(t *testing.T) {
 	// Stop and close
 	session.Close()
 }
+
+func TestDiffArgsSchemaValidation(t *testing.T) {
+	session := createTestSession(t, nil)
+
+	// Valid diff args should work
+	args := DiffArgs{
+		Bases:       []string{"main", "HEAD"},
+		CurrentBase: 0,
+		Paths:       []string{"internal/"},
+		Extensions:  []string{"go"},
+	}
+	session.SetDiffArgs(args)
+
+	retrieved := session.GetDiffArgs()
+	assert.Equals(t, len(retrieved.Bases), 2, "should have 2 bases")
+	assert.Equals(t, retrieved.CurrentBase, 0, "current base should be 0")
+}
+
+func TestDiffArgsSchemaRejectsInvalidCurrentBase(t *testing.T) {
+	session := createTestSession(t, nil)
+
+	// Attempting to set invalid currentBase type should return error
+	err := session.SetValueAtKey(KeyDiffArgs, map[string]any{
+		"bases":       []any{"main"},
+		"currentBase": "not-a-number", // invalid: should be integer
+		"paths":       []any{},
+		"extensions":  []any{},
+	})
+	assert.NotNil(t, err, "should return error when setting invalid currentBase type")
+}
+
+func TestDiffArgsSchemaRejectsInvalidBasesType(t *testing.T) {
+	session := createTestSession(t, nil)
+
+	// Attempting to set invalid bases type should return error
+	err := session.SetValueAtKey(KeyDiffArgs, map[string]any{
+		"bases":       []any{123}, // invalid: items should be strings
+		"currentBase": 0,
+		"paths":       []any{},
+		"extensions":  []any{},
+	})
+	assert.NotNil(t, err, "should return error when setting invalid bases type")
+}


### PR DESCRIPTION
- Define DiffArgsSchema with validation for bases, currentBase, paths, extensions
- Register schema via WithSchema during NewSession initialization
- Add tests for valid args and invalid type rejection