### PR TITLE
Print grpcurl and curl commands on API server startup

### DIFF
--- a/agents/logs/20260127-064112-print-grpcurl-command.md
+++ b/agents/logs/20260127-064112-print-grpcurl-command.md
@@ -1,0 +1,39 @@
+# Task: Print grpcurl command on API server startup
+
+**Started:** 2026-01-27 06:41:12
+**Ended:** 2026-01-27 06:43:00
+**Strategy:** Feature (TDD)
+**Status:** Completed
+**Complexity:** Simple
+**Used Models:** Opus
+
+## Objective
+When starting "critic api", print the full grpcurl command to fetch a GetLastChangeRequest.
+
+## Progress
+- [x] Explored codebase to understand API server structure
+- [x] Found server implementation in src/api/server/server.go
+- [x] Add grpcurl command print to server startup
+- [x] Add curl command print (user requested)
+- [x] Add handler at root path for grpcurl compatibility
+- [x] Test the output
+
+## Obstacles
+- **Issue:** grpcurl expects gRPC handlers at root path, but server mounted at `/api` prefix
+  **Resolution:** Added handler at both `/api` prefix and root path
+
+## Outcome
+Server now prints both grpcurl and curl commands on startup:
+```
+API server listening on :65432
+
+Test with grpcurl:
+  grpcurl -plaintext -import-path src/api/proto -proto critic.proto localhost:65432 critic.v1.CriticService/GetLastChange
+
+Test with curl:
+  curl -X POST http://localhost:65432/api/critic.v1.CriticService/GetLastChange -H 'Content-Type: application/json' -d '{}'
+```
+
+## Insights
+- Connect servers support gRPC protocol but path prefixes break grpcurl compatibility
+- Solution: mount handlers at both custom prefix and root path

--- a/src/api/server/server.go
+++ b/src/api/server/server.go
@@ -48,7 +48,14 @@ func (s *Server) Start() error {
 	path, handler := apiconnect.NewCriticServiceHandler(s)
 	mux.Handle("/api"+path, http.StripPrefix("/api", handler))
 
+	// Also register at root path for grpcurl compatibility
+	mux.Handle(path, handler)
+
 	addr := fmt.Sprintf(":%d", s.config.Port)
 	fmt.Printf("API server listening on %s\n", addr)
+	fmt.Printf("\nTest with grpcurl:\n")
+	fmt.Printf("  grpcurl -plaintext -import-path src/api/proto -proto critic.proto localhost:%d critic.v1.CriticService/GetLastChange\n", s.config.Port)
+	fmt.Printf("\nTest with curl:\n")
+	fmt.Printf("  curl -X POST http://localhost:%d/api/critic.v1.CriticService/GetLastChange -H 'Content-Type: application/json' -d '{}'\n", s.config.Port)
 	return http.ListenAndServe(addr, mux)
 }


### PR DESCRIPTION
When starting the API server, print example commands to test the GetLastChange endpoint. Also register the handler at the root path for grpcurl compatibility.

https://claude.ai/code/session_01CKyLiCgWDYnPZyxG1ZqNQT