### PR TITLE
Add tasks.RunExclusively utility for exclusive background task execution

### DIFF
--- a/agents/logs/20260127-071918-add-task-exclusive-utility.md
+++ b/agents/logs/20260127-071918-add-task-exclusive-utility.md
@@ -1,0 +1,37 @@
+# Task: Add task.RunExclusively utility
+
+**Started:** 2026-01-27 07:19:18
+**Ended:** 2026-01-27 07:25:00
+**Strategy:** Feature (TDD)
+**Status:** Completed
+**Complexity:** Simple
+**Used Models:** Opus 4.5
+**Token usage (Estimated):** ~10k input, ~5k output
+
+## Objective
+Create a task utility in `simple-go/tasks` that allows running functions exclusively by ID:
+- `task.RunExclusively(id, taskFunc)` - runs a function exclusively
+- If a task with the same ID is already running, return an error
+- Returns a `Task` object with a channel to pull results from
+- The `Task` object has an `Abort()` method to terminate the task
+
+## Progress
+- [x] Create progress log
+- [x] Write failing tests for RunExclusively
+- [x] Implement Task struct and RunExclusively function
+- [x] Implement Abort functionality
+- [x] Run tests and verify all pass
+- [x] Commit changes
+
+## Obstacles
+None
+
+## Outcome
+Implemented `simple-go/tasks` package with:
+- `RunExclusively[T any](id string, taskFunc func() T)` - run a task exclusively by ID
+- `RunExclusivelyWithContext[T any](id string, taskFunc func(*Context) T)` - run with abort-aware context
+- `Task[T]` struct with `Done()` channel and `Abort()` method
+- `Context` struct with `IsAborted()` for cooperative cancellation
+
+## Insights
+- Using variadic for optional reduce parameter was over-engineering; simpler interface is better

--- a/simple-go/tasks/exclusive.go
+++ b/simple-go/tasks/exclusive.go
@@ -1,0 +1,148 @@
+package tasks
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
+
+// Context provides a way for tasks to check if they have been aborted.
+type Context struct {
+	aborted atomic.Bool
+}
+
+// IsAborted returns true if the task has been aborted.
+func (c *Context) IsAborted() bool {
+	return c.aborted.Load()
+}
+
+// Task represents a running exclusive task.
+type Task[T any] struct {
+	id      string
+	done    chan T
+	ctx     *Context
+	cleanup func()
+}
+
+// Done returns a channel that will receive the result when the task completes.
+func (t *Task[T]) Done() <-chan T {
+	return t.done
+}
+
+// Abort signals the task to stop and removes it from the running tasks.
+// The task function should check Context.IsAborted() to respond to abort requests.
+// After Abort is called, the Done channel will receive the zero value of T.
+func (t *Task[T]) Abort() {
+	t.ctx.aborted.Store(true)
+	t.cleanup()
+	// Send zero value to unblock any waiters
+	var zero T
+	select {
+	case t.done <- zero:
+	default:
+		// Channel already has a value or is full
+	}
+}
+
+// registry holds all currently running tasks
+var registry = &taskRegistry{
+	tasks: make(map[string]any),
+}
+
+type taskRegistry struct {
+	mu    sync.Mutex
+	tasks map[string]any
+}
+
+func (r *taskRegistry) tryRegister(id string, task any) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.tasks[id]; exists {
+		return fmt.Errorf("task %q is already running", id)
+	}
+	r.tasks[id] = task
+	return nil
+}
+
+func (r *taskRegistry) unregister(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.tasks, id)
+}
+
+// RunExclusively runs a task function exclusively by ID.
+// If a task with the same ID is already running, it returns an error.
+// The returned Task provides a Done() channel to receive the result
+// and an Abort() method to cancel the task.
+func RunExclusively[T any](id string, taskFunc func() T) (*Task[T], error) {
+	ctx := &Context{}
+
+	task := &Task[T]{
+		id:   id,
+		done: make(chan T, 1),
+		ctx:  ctx,
+		cleanup: func() {
+			registry.unregister(id)
+		},
+	}
+
+	if err := registry.tryRegister(id, task); err != nil {
+		return nil, err
+	}
+
+	go func() {
+		defer task.cleanup()
+
+		// Run the task
+		result := taskFunc()
+
+		// Only send result if not aborted
+		if !ctx.IsAborted() {
+			select {
+			case task.done <- result:
+			default:
+				// Channel already has a value (from abort)
+			}
+		}
+	}()
+
+	return task, nil
+}
+
+// RunExclusivelyWithContext runs a task function exclusively by ID, providing
+// a Context that the task can use to check for abort signals.
+func RunExclusivelyWithContext[T any](id string, taskFunc func(*Context) T) (*Task[T], error) {
+	ctx := &Context{}
+
+	task := &Task[T]{
+		id:   id,
+		done: make(chan T, 1),
+		ctx:  ctx,
+		cleanup: func() {
+			registry.unregister(id)
+		},
+	}
+
+	if err := registry.tryRegister(id, task); err != nil {
+		return nil, err
+	}
+
+	go func() {
+		defer task.cleanup()
+
+		// Run the task with context
+		result := taskFunc(ctx)
+
+		// Only send result if not aborted
+		if !ctx.IsAborted() {
+			select {
+			case task.done <- result:
+			default:
+				// Channel already has a value (from abort)
+			}
+		}
+	}()
+
+	return task, nil
+}

--- a/simple-go/tasks/exclusive_test.go
+++ b/simple-go/tasks/exclusive_test.go
@@ -1,0 +1,197 @@
+package tasks
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/radiospiel/critic/simple-go/assert"
+)
+
+func TestRunExclusively_BasicExecution(t *testing.T) {
+	// A simple task that returns a value
+	task, err := RunExclusively("test-1", func() int {
+		return 42
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, task)
+
+	// Wait for result
+	result := <-task.Done()
+	assert.Equals(t, result, 42)
+}
+
+func TestRunExclusively_RejectsSecondTaskWithSameID(t *testing.T) {
+	started := make(chan struct{})
+	blocker := make(chan struct{})
+
+	// Start a long-running task
+	task1, err := RunExclusively("exclusive-task", func() int {
+		close(started)
+		<-blocker // Block until we signal
+		return 1
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, task1)
+
+	// Wait for task1 to start
+	<-started
+
+	// Try to start another task with the same ID
+	task2, err := RunExclusively("exclusive-task", func() int {
+		return 2
+	})
+
+	assert.NotNil(t, err)
+	assert.Nil(t, task2)
+	assert.Contains(t, err.Error(), "exclusive-task")
+	assert.Contains(t, err.Error(), "already running")
+
+	// Clean up
+	close(blocker)
+	<-task1.Done()
+}
+
+func TestRunExclusively_AllowsNewTaskAfterPreviousCompletes(t *testing.T) {
+	// First task
+	task1, err := RunExclusively("reusable-id", func() int {
+		return 1
+	})
+	assert.NoError(t, err)
+	result1 := <-task1.Done()
+	assert.Equals(t, result1, 1)
+
+	// Second task with same ID should work now
+	task2, err := RunExclusively("reusable-id", func() int {
+		return 2
+	})
+	assert.NoError(t, err)
+	result2 := <-task2.Done()
+	assert.Equals(t, result2, 2)
+}
+
+func TestRunExclusively_DifferentIDsCanRunConcurrently(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	started1 := make(chan struct{})
+	started2 := make(chan struct{})
+	done := make(chan struct{})
+
+	task1, err := RunExclusively("id-a", func() int {
+		close(started1)
+		wg.Done()
+		<-done
+		return 1
+	})
+	assert.NoError(t, err)
+
+	task2, err := RunExclusively("id-b", func() int {
+		close(started2)
+		wg.Done()
+		<-done
+		return 2
+	})
+	assert.NoError(t, err)
+
+	// Both should have started
+	<-started1
+	<-started2
+
+	// Let them finish
+	close(done)
+
+	result1 := <-task1.Done()
+	result2 := <-task2.Done()
+
+	assert.Equals(t, result1, 1)
+	assert.Equals(t, result2, 2)
+}
+
+func TestTask_Abort(t *testing.T) {
+	blocker := make(chan struct{})
+	taskStarted := make(chan struct{})
+
+	task, err := RunExclusively("abortable", func() int {
+		close(taskStarted)
+		<-blocker // This will block forever unless aborted
+		return 42
+	})
+	assert.NoError(t, err)
+
+	// Wait for task to start
+	<-taskStarted
+
+	// Abort the task
+	task.Abort()
+
+	// Task should complete (with zero value since aborted)
+	select {
+	case <-task.Done():
+		// Good - task was aborted
+	case <-time.After(1 * time.Second):
+		t.Fatal("task did not abort within timeout")
+	}
+
+	// Should be able to start a new task with the same ID
+	task2, err := RunExclusively("abortable", func() int {
+		return 99
+	})
+	assert.NoError(t, err)
+	result := <-task2.Done()
+	assert.Equals(t, result, 99)
+}
+
+func TestTask_AbortContext(t *testing.T) {
+	// Test that we can check for abort inside the task using Context
+	taskCompleted := make(chan bool)
+
+	task, err := RunExclusivelyWithContext("context-abort", func(ctx *Context) int {
+		for i := 0; i < 100; i++ {
+			if ctx.IsAborted() {
+				taskCompleted <- false
+				return 0
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		taskCompleted <- true
+		return 42
+	})
+	assert.NoError(t, err)
+
+	// Give task time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Abort
+	task.Abort()
+
+	// Task should have detected abort
+	completed := <-taskCompleted
+	assert.Equals(t, completed, false)
+}
+
+func TestRunExclusively_StringType(t *testing.T) {
+	task, err := RunExclusively("string-task", func() string {
+		return "hello world"
+	})
+	assert.NoError(t, err)
+	result := <-task.Done()
+	assert.Equals(t, result, "hello world")
+}
+
+func TestRunExclusively_StructType(t *testing.T) {
+	type Result struct {
+		Value int
+		Err   error
+	}
+
+	task, err := RunExclusively("struct-task", func() Result {
+		return Result{Value: 42, Err: errors.New("test error")}
+	})
+	assert.NoError(t, err)
+	result := <-task.Done()
+	assert.Equals(t, result.Value, 42)
+	assert.NotNil(t, result.Err)
+}


### PR DESCRIPTION
Provides a mechanism to run functions exclusively by ID - if a task with the same ID is already running, the call returns an error. The returned Task object provides a Done() channel for results and Abort() for cooperative cancellation.

https://claude.ai/code/session_01E4toEwCQHizd1USrftnTm2