### PR TITLE
Expand syntax highlighting support for 80+ file types

### DIFF
--- a/agents/logs/20260128-105105-add-syntax-highlighting.md
+++ b/agents/logs/20260128-105105-add-syntax-highlighting.md
@@ -1,0 +1,46 @@
+# Add Syntax Highlighting for Well-Known Languages
+
+Started: 2026-01-28 10:51:05
+Ended: 2026-01-28 10:55:00
+Complexity: Simple
+
+## Summary
+Enhance syntax highlighting in the webui by adding support for more well-known programming languages.
+
+## Task Type
+**Feature** - Adding new functionality (extended language support)
+
+## Progress
+
+- [x] Explore codebase structure
+- [x] Review existing implementation
+- [x] Extend language mappings
+- [x] Verify build compiles
+- [x] Commit and push
+
+## Findings
+
+The webui already had syntax highlighting via highlight.js, but the language mapping was limited to ~24 extensions.
+
+Extended to ~80+ file extensions covering:
+- JavaScript/TypeScript (including .mjs, .cjs, .mts, .cts)
+- Python, Go, Rust, Ruby (with Ruby config files like Gemfile, Rakefile)
+- Java/JVM languages (Kotlin, Scala, Groovy, Clojure)
+- C/C++/Objective-C with all common extensions
+- C#, F#
+- Web files (HTML, XML, Vue, Svelte, Astro)
+- CSS/SCSS/Less/Stylus
+- Shell scripts (Bash, Zsh, Fish, PowerShell, DOS)
+- Data formats (JSON, YAML, TOML, INI)
+- Database (SQL, PgSQL)
+- Other languages (PHP, Swift, Perl, Lua, R, Julia, Elixir, Erlang, Haskell, OCaml, Elm, Dart, Zig, Nim, D)
+- Lisp family (Lisp, Scheme)
+- Config/DevOps (Proto, GraphQL, Terraform/HCL, Nix)
+- Assembly
+- Special files (Dockerfile, Makefile, .env files, .gitignore)
+
+Also added case-insensitive extension matching.
+
+## Obstacles
+
+None - straightforward extension of existing functionality.

--- a/src/webui/frontend/src/components/DiffView.tsx
+++ b/src/webui/frontend/src/components/DiffView.tsx
@@ -14,34 +14,194 @@ function getFileExtension(path: string): string {
 }
 
 function getLanguage(path: string): string | undefined {
-  const ext = getFileExtension(path)
+  const ext = getFileExtension(path).toLowerCase()
+
+  // Handle special filenames without extensions
+  const filename = path.split('/').pop()?.toLowerCase() || ''
+  const filenameMap: Record<string, string> = {
+    'dockerfile': 'dockerfile',
+    'makefile': 'makefile',
+    'gnumakefile': 'makefile',
+    'cmakelists.txt': 'cmake',
+    'rakefile': 'ruby',
+    'gemfile': 'ruby',
+    'podfile': 'ruby',
+    'vagrantfile': 'ruby',
+    'brewfile': 'ruby',
+    '.gitignore': 'bash',
+    '.dockerignore': 'bash',
+    '.env': 'bash',
+    '.env.local': 'bash',
+    '.env.development': 'bash',
+    '.env.production': 'bash',
+  }
+
+  if (filenameMap[filename]) {
+    return filenameMap[filename]
+  }
+
   const extMap: Record<string, string> = {
+    // JavaScript/TypeScript
     ts: 'typescript',
     tsx: 'typescript',
+    mts: 'typescript',
+    cts: 'typescript',
     js: 'javascript',
     jsx: 'javascript',
+    mjs: 'javascript',
+    cjs: 'javascript',
+
+    // Python
     py: 'python',
+    pyw: 'python',
+    pyi: 'python',
+
+    // Go
     go: 'go',
+    mod: 'go',
+
+    // Rust
     rs: 'rust',
+
+    // Ruby
     rb: 'ruby',
+    erb: 'erb',
+    rake: 'ruby',
+    gemspec: 'ruby',
+
+    // Java/JVM
     java: 'java',
+    kt: 'kotlin',
+    kts: 'kotlin',
+    scala: 'scala',
+    groovy: 'groovy',
+    gradle: 'groovy',
+    clj: 'clojure',
+    cljs: 'clojure',
+    cljc: 'clojure',
+
+    // C/C++/Objective-C
     c: 'c',
-    cpp: 'cpp',
     h: 'c',
+    cpp: 'cpp',
+    cxx: 'cpp',
+    cc: 'cpp',
     hpp: 'cpp',
+    hxx: 'cpp',
+    hh: 'cpp',
+    m: 'objectivec',
+    mm: 'objectivec',
+
+    // C#/F#
     cs: 'csharp',
+    fs: 'fsharp',
+    fsx: 'fsharp',
+    fsi: 'fsharp',
+
+    // Web
+    html: 'xml',
+    htm: 'xml',
+    xhtml: 'xml',
+    xml: 'xml',
+    svg: 'xml',
+    vue: 'xml',
+    svelte: 'xml',
+    astro: 'xml',
+
+    // CSS/Styling
     css: 'css',
     scss: 'scss',
-    html: 'html',
-    xml: 'xml',
-    json: 'json',
-    yaml: 'yaml',
-    yml: 'yaml',
-    md: 'markdown',
+    sass: 'scss',
+    less: 'less',
+    styl: 'stylus',
+
+    // Shell
     sh: 'bash',
     bash: 'bash',
+    zsh: 'bash',
+    fish: 'bash',
+    ps1: 'powershell',
+    psm1: 'powershell',
+    bat: 'dos',
+    cmd: 'dos',
+
+    // Data formats
+    json: 'json',
+    jsonc: 'json',
+    json5: 'json',
+    yaml: 'yaml',
+    yml: 'yaml',
+    toml: 'ini',
+    ini: 'ini',
+    cfg: 'ini',
+    conf: 'ini',
+    properties: 'properties',
+
+    // Documentation
+    md: 'markdown',
+    markdown: 'markdown',
+    rst: 'plaintext',
+    txt: 'plaintext',
+    tex: 'latex',
+
+    // Database
     sql: 'sql',
+    pgsql: 'pgsql',
+    plsql: 'sql',
+
+    // Other languages
+    php: 'php',
+    swift: 'swift',
+    pl: 'perl',
+    pm: 'perl',
+    lua: 'lua',
+    r: 'r',
+    R: 'r',
+    jl: 'julia',
+    ex: 'elixir',
+    exs: 'elixir',
+    erl: 'erlang',
+    hrl: 'erlang',
+    hs: 'haskell',
+    lhs: 'haskell',
+    ml: 'ocaml',
+    mli: 'ocaml',
+    elm: 'elm',
+    dart: 'dart',
+    zig: 'zig',
+    nim: 'nim',
+    v: 'verilog',
+    sv: 'verilog',
+    vhd: 'vhdl',
+    vhdl: 'vhdl',
+    d: 'd',
+
+    // Lisp family
+    lisp: 'lisp',
+    el: 'lisp',
+    scm: 'scheme',
+    rkt: 'scheme',
+
+    // Config/DevOps
     proto: 'protobuf',
+    graphql: 'graphql',
+    gql: 'graphql',
+    tf: 'hcl',
+    hcl: 'hcl',
+    nix: 'nix',
+    dhall: 'haskell',
+
+    // Assembly
+    asm: 'x86asm',
+    s: 'x86asm',
+
+    // Misc
+    coffee: 'coffeescript',
+    diff: 'diff',
+    patch: 'diff',
+    sol: 'solidity',
+    wasm: 'wasm',
+    wat: 'wasm',
   }
   return extMap[ext]
 }


### PR DESCRIPTION
## Summary
Extended syntax highlighting in the webui to support over 80 file extensions and special filenames, significantly improving code readability across a wider range of programming languages and file types.

## Changes
- **Extended language mappings** from ~24 to ~80+ file extensions in `DiffView.tsx`
- **Added case-insensitive extension matching** for more robust file type detection
- **Implemented special filename handling** for files without extensions (Dockerfile, Makefile, .env files, .gitignore, etc.)

## Supported Languages
Now includes comprehensive support for:
- **JavaScript/TypeScript**: Added .mjs, .cjs, .mts, .cts variants
- **Python**: Added .pyw, .pyi variants
- **JVM languages**: Kotlin, Scala, Groovy, Clojure
- **C/C++/Objective-C**: All common extensions (.cxx, .cc, .hxx, .hh, .m, .mm)
- **C#/F#**: Full F# support
- **Web**: Vue, Svelte, Astro components
- **Styling**: SASS, Less, Stylus
- **Shell**: Bash, Zsh, Fish, PowerShell, DOS
- **Data formats**: JSON5, JSONC, TOML, INI, Properties
- **Database**: SQL, PostgreSQL, PL/SQL
- **Other languages**: PHP, Swift, Perl, Lua, R, Julia, Elixir, Erlang, Haskell, OCaml, Elm, Dart, Zig, Nim, D, Verilog, VHDL
- **Lisp family**: Lisp, Scheme
- **DevOps/Config**: GraphQL, Terraform/HCL, Nix, Protobuf
- **Special files**: Dockerfile, Makefile, CMakeLists.txt, Rakefile, Gemfile, Podfile, Vagrantfile, Brewfile, .env variants, .gitignore, .dockerignore

## Implementation Details
- Special filenames are matched first before extension-based matching
- All extension matching is case-insensitive for better reliability
- Leverages existing highlight.js integration without adding new dependencies

https://claude.ai/code/session_01YRzSgVVvnNri8jGZgY2Gz3