### PR TITLE
Add support for category paths

### DIFF
--- a/src/api/critic.pb.go
+++ b/src/api/critic.pb.go
@@ -2781,7 +2781,10 @@ type FileCategory struct {
 	// name is the category name (e.g., "test", "hidden", "docs").
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// patterns is the list of gitignore-style glob patterns for this category.
-	Patterns      []string `protobuf:"bytes,2,rep,name=patterns,proto3" json:"patterns,omitempty"`
+	Patterns []string `protobuf:"bytes,2,rep,name=patterns,proto3" json:"patterns,omitempty"`
+	// path is an optional prefix. When set, the category header shows "(in <path>)"
+	// and file paths have the "<path>/" prefix removed in the file list.
+	Path          string `protobuf:"bytes,3,opt,name=path,proto3" json:"path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2828,6 +2831,13 @@ func (x *FileCategory) GetPatterns() []string {
 		return x.Patterns
 	}
 	return nil
+}
+
+func (x *FileCategory) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
 }
 
 // EditorConfig holds editor integration settings.
@@ -3162,10 +3172,11 @@ const file_critic_proto_rawDesc = "" +
 	"categories\x18\x02 \x03(\v2\x17.critic.v1.FileCategoryR\n" +
 	"categories\x12/\n" +
 	"\x06editor\x18\x03 \x01(\v2\x17.critic.v1.EditorConfigR\x06editor\x12)\n" +
-	"\x05error\x18\x0f \x01(\v2\x13.critic.v1.RpcErrorR\x05error\">\n" +
+	"\x05error\x18\x0f \x01(\v2\x13.critic.v1.RpcErrorR\x05error\"R\n" +
 	"\fFileCategory\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
-	"\bpatterns\x18\x02 \x03(\tR\bpatterns\" \n" +
+	"\bpatterns\x18\x02 \x03(\tR\bpatterns\x12\x12\n" +
+	"\x04path\x18\x03 \x01(\tR\x04path\" \n" +
 	"\fEditorConfig\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\"\\\n" +
 	"\x18CreateExplanationRequest\x12\x12\n" +

--- a/src/api/proto/critic.proto
+++ b/src/api/proto/critic.proto
@@ -444,6 +444,9 @@ message FileCategory {
   string name = 1;
   // patterns is the list of gitignore-style glob patterns for this category.
   repeated string patterns = 2;
+  // path is an optional prefix. When set, the category header shows "(in <path>)"
+  // and file paths have the "<path>/" prefix removed in the file list.
+  string path = 3;
 }
 
 // EditorConfig holds editor integration settings.

--- a/src/api/server/get_project_config.go
+++ b/src/api/server/get_project_config.go
@@ -26,6 +26,7 @@ func getProjectConfigImpl(server *Server) (*api.GetProjectConfigResponse, error)
 		categories = append(categories, &api.FileCategory{
 			Name:     cat.Name,
 			Patterns: cat.Patterns,
+			Path:     cat.Path,
 		})
 	}
 

--- a/src/config/project.go
+++ b/src/config/project.go
@@ -14,6 +14,7 @@ import (
 type FileCategory struct {
 	Name     string   `yaml:"name" json:"name"`
 	Patterns []string `yaml:"patterns" json:"patterns"`
+	Path     string   `yaml:"path,omitempty" json:"path,omitempty"`
 }
 
 // EditorConfig holds editor integration settings.

--- a/src/config/project_test.go
+++ b/src/config/project_test.go
@@ -308,6 +308,24 @@ func TestCategorizeFile_CategoryOrder(t *testing.T) {
 	assert.Equals(t, result, "first", "first matching category should win")
 }
 
+func TestParseProjectConfig_CategoryPath(t *testing.T) {
+	yaml := `
+categories:
+  - name: Backend
+    path: "src"
+    patterns:
+      - "src/**/*.go"
+  - name: Frontend
+    patterns:
+      - "web/**/*"
+`
+	config, err := ParseProjectConfig([]byte(yaml))
+	assert.NoError(t, err)
+	assert.Equals(t, len(config.Categories), 2, "categories count")
+	assert.Equals(t, config.Categories[0].Path, "src", "Backend path")
+	assert.Equals(t, config.Categories[1].Path, "", "Frontend path should be empty")
+}
+
 // TestCategorizeFile_EmptyCategories tests behavior with no categories configured.
 func TestCategorizeFile_EmptyCategories(t *testing.T) {
 	config := &ProjectConfig{}

--- a/src/webui/frontend/src/components/FileList.tsx
+++ b/src/webui/frontend/src/components/FileList.tsx
@@ -97,6 +97,7 @@ function FileList({ files, allConversations, selectedFile, onSelectFile, onSelec
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [categoryNames, setCategoryNames] = useState<string[]>([])
+  const [categoryPaths, setCategoryPaths] = useState<Map<string, string>>(new Map())
   const [resolvingIds, setResolvingIds] = useState<Set<string>>(new Set())
   const [showUntracked, setShowUntracked] = useState(false)
   const [openCategory, setOpenCategory] = useState<string>('')
@@ -153,6 +154,11 @@ function FileList({ files, allConversations, selectedFile, onSelectFile, onSelec
         } else {
           const names = response.categories.map((c) => c.name)
           setCategoryNames(names)
+          const paths = new Map<string, string>()
+          for (const c of response.categories) {
+            if (c.path) paths.set(c.name, c.path)
+          }
+          setCategoryPaths(paths)
           if (names.length > 0) {
             setOpenCategory(names[0])
           }
@@ -581,8 +587,9 @@ function FileList({ files, allConversations, selectedFile, onSelectFile, onSelec
         ) : (
           <>
             {(() => {
-              const renderFileItem = (file: FileSummary) => {
+              const renderFileItem = (file: FileSummary, pathPrefix?: string) => {
                 const path = getFilePath(file)
+                const displayPath = pathPrefix && path.startsWith(pathPrefix + '/') ? path.slice(pathPrefix.length + 1) : path
                 const isSelected = selectedFile === path
                 const summary = conversationSummaries.get(path)
                 return (
@@ -599,7 +606,7 @@ function FileList({ files, allConversations, selectedFile, onSelectFile, onSelec
                     <span className={`file-status status-${getStatusLabel(file.status).toLowerCase()}`}>
                       {getStatusLabel(file.status)}
                     </span>
-                    <span className="file-path">{path}</span>
+                    <span className="file-path">{displayPath}</span>
                     {summary && summary.unresolvedCount > 0 && (
                       <span className="conversation-icon unresolved" title={`${summary.unresolvedCount} open`}>
                         {summary.unresolvedCount}
@@ -639,7 +646,8 @@ function FileList({ files, allConversations, selectedFile, onSelectFile, onSelec
 
               return fileSections.map((section) => {
                 const isOpen = openCategory === section.name
-                const label = section.name.charAt(0).toUpperCase() + section.name.slice(1)
+                const catPath = categoryPaths.get(section.name)
+                const label = section.name.charAt(0).toUpperCase() + section.name.slice(1) + (catPath ? ` (in ${catPath})` : '')
                 let catUnresolved = 0
                 let catExplanations = 0
                 for (const f of section.files) {
@@ -669,7 +677,7 @@ function FileList({ files, allConversations, selectedFile, onSelectFile, onSelec
                     </div>
                     <div className={`file-category-collapse${isOpen ? ' open' : ''}`}>
                       <ul className="file-category-files">
-                        {section.files.map(renderFileItem)}
+                        {section.files.map((file) => renderFileItem(file, catPath))}
                       </ul>
                     </div>
                   </li>

--- a/src/webui/frontend/src/gen/critic_pb.ts
+++ b/src/webui/frontend/src/gen/critic_pb.ts
@@ -2399,6 +2399,14 @@ export class FileCategory extends Message$1<FileCategory> {
    */
   patterns: string[] = [];
 
+  /**
+   * path is an optional prefix. When set, the category header shows "(in <path>)"
+   * and file paths have the "<path>/" prefix removed in the file list.
+   *
+   * @generated from field: string path = 3;
+   */
+  path = "";
+
   constructor(data?: PartialMessage<FileCategory>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2409,6 +2417,7 @@ export class FileCategory extends Message$1<FileCategory> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "patterns", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 3, name: "path", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): FileCategory {


### PR DESCRIPTION
## Summary
- Added optional `path` field to `FileCategory` (Go config, protobuf, generated TS)
- When a category has a path, the category header shows "(in <path>)" label
- File paths within that category have the `<path>/` prefix stripped in the file list display
- Full paths are preserved in title tooltip and for file selection/navigation

Closes #116

## Test plan
- [ ] Add `path: "src"` to a category in `project.critic` and verify the header shows "(in src)"
- [ ] Verify file paths within that category have `src/` prefix stripped
- [ ] Verify categories without a path are unaffected
- [ ] Run `go test ./src/config/ ./src/api/server/` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)