### PR TITLE
Use OSC 8 hyperlinks for clickable links in log output

### DIFF
--- a/simple-go/logger/hyperlink_test.go
+++ b/simple-go/logger/hyperlink_test.go
@@ -1,0 +1,66 @@
+package logger
+
+import (
+	"testing"
+)
+
+func TestLinkifyURLs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no URLs",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "http URL",
+			input:    "visit http://localhost:8080 now",
+			expected: "visit \033]8;;http://localhost:8080\033\\http://localhost:8080\033]8;;\033\\ now",
+		},
+		{
+			name:     "https URL",
+			input:    "see https://example.com/path",
+			expected: "see \033]8;;https://example.com/path\033\\https://example.com/path\033]8;;\033\\",
+		},
+		{
+			name:     "multiple URLs",
+			input:    "http://a.com and http://b.com",
+			expected: "\033]8;;http://a.com\033\\http://a.com\033]8;;\033\\ and \033]8;;http://b.com\033\\http://b.com\033]8;;\033\\",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := linkifyURLs(tt.input)
+			if result != tt.expected {
+				t.Errorf("linkifyURLs(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHyperlink_ColorsDisabled(t *testing.T) {
+	old := sharedDest.enableColors
+	sharedDest.enableColors = false
+	defer func() { sharedDest.enableColors = old }()
+
+	result := Hyperlink("http://example.com", "click here")
+	if result != "click here" {
+		t.Errorf("Hyperlink() = %q, want plain text when colors disabled", result)
+	}
+}
+
+func TestHyperlink_ColorsEnabled(t *testing.T) {
+	old := sharedDest.enableColors
+	sharedDest.enableColors = true
+	defer func() { sharedDest.enableColors = old }()
+
+	result := Hyperlink("http://example.com", "click here")
+	expected := "\033]8;;http://example.com\033\\click here\033]8;;\033\\"
+	if result != expected {
+		t.Errorf("Hyperlink() = %q, want %q", result, expected)
+	}
+}

--- a/simple-go/logger/logger.go
+++ b/simple-go/logger/logger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -51,6 +52,31 @@ func SetLevelColor(level LevelT, color string) {
 }
 
 const colorReset = "\033[0m"
+
+// OSC 8 hyperlink escape sequences for clickable links in supported terminals.
+const (
+	oscOpen  = "\033]8;;"
+	oscClose = "\033\\"
+)
+
+// urlPattern matches http:// and https:// URLs in log messages.
+var urlPattern = regexp.MustCompile(`https?://[^\s"'` + "`" + `\x00-\x1f]+`)
+
+// Hyperlink wraps text as a clickable OSC 8 hyperlink pointing to url.
+// Only produces escape sequences when the log destination is a TTY.
+func Hyperlink(url, text string) string {
+	if !sharedDest.enableColors {
+		return text
+	}
+	return oscOpen + url + oscClose + text + oscOpen + oscClose
+}
+
+// linkifyURLs replaces bare URLs in s with OSC 8 clickable hyperlinks.
+func linkifyURLs(s string) string {
+	return urlPattern.ReplaceAllStringFunc(s, func(url string) string {
+		return oscOpen + url + oscClose + url + oscOpen + oscClose
+	})
+}
 
 // SimpleLogger is a logger with support for topics, and filenames
 // Note that most calls will call directly to the sharedInstance, but a caller
@@ -164,8 +190,9 @@ func processLogEntry(entry logMessage) {
 	}
 	msg = entry.level.String() + ": " + msg
 
-	// apply color
+	// apply color and hyperlinks
 	if sharedDest.enableColors {
+		msg = linkifyURLs(msg)
 		color := levelColors[entry.level]
 		if color != "" {
 			msg = color + msg + colorReset

--- a/src/api/server/server.go
+++ b/src/api/server/server.go
@@ -269,7 +269,8 @@ func (s *Server) Start() error {
 	// Start server in goroutine
 	serverErr := make(chan error, 1)
 	go func() {
-		fmt.Printf("Critic running at http://localhost%s\n", addr)
+		url := fmt.Sprintf("http://localhost%s", addr)
+		fmt.Printf("Critic running at %s\n", logger.Hyperlink(url, url))
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			serverErr <- err
 		}


### PR DESCRIPTION
## Summary
- Added `linkifyURLs()` to automatically wrap `http://` and `https://` URLs in OSC 8 hyperlink sequences in log output when on a TTY
- Added exported `Hyperlink(url, text)` function for explicit clickable link creation
- Updated the server startup message to use a clickable hyperlink
- OSC 8 sequences are only emitted when the log destination is a terminal (same gating as color output)

Closes #117

## Test plan
- [ ] Run `go test ./simple-go/logger/` — passes
- [ ] Start the server and verify the startup URL is clickable in a modern terminal (iTerm2, Ghostty, etc.)
- [ ] Verify log messages containing URLs show as clickable links

🤖 Generated with [Claude Code](https://claude.com/claude-code)