### PR TITLE
Improve branch detection with single diff base and git log discovery …

### DIFF
--- a/agents/logs/20260304-101500-improve-branch-detection.md
+++ b/agents/logs/20260304-101500-improve-branch-detection.md
@@ -1,0 +1,30 @@
+# Task: Improve branch detection (#128)
+
+**Started:** 2026-03-04 10:15:00
+**Ended:** 2026-03-04 10:35:00
+**Strategy:** Refactoring
+**Status:** Completed
+**Complexity:** Medium
+**Used Models:** Opus
+**Token usage (Estimated):** 80k input, 20k output
+
+## Objective
+Simplify branch detection by moving from multiple diff bases to a single one,
+using git log --decorate-refs for branch discovery, and removing custom sorting.
+
+## Progress
+- [x] Change DiffBases (plural list) to DiffBase (singular string) in config
+- [x] Auto-detect master/main when no diff base configured, fail if neither exists
+- [x] Replace LocalBranchesOnPath to use git log --decorate-refs with lo filtering
+- [x] Remove SortRefsByGraphOrder and graphDistance (let git dictate order)
+- [x] Remove SortByGraphOrder from GitOps interface
+- [x] Update project.critic to use singular diffbase field
+- [x] Update tests for new API
+- [x] All tests pass
+
+## Obstacles
+None.
+
+## Outcome
+Branch detection simplified: single diff base in config, auto-detection of
+master/main, git log-based discovery with lo filtering, no custom sorting.

--- a/project.critic
+++ b/project.critic
@@ -1,9 +1,7 @@
 project:
   name: "critic"
 
-diffbases:
-  - green
-  - master
+diffbase: master
 
 # paths:
 #   - src

--- a/src/cli/httpd.go
+++ b/src/cli/httpd.go
@@ -73,7 +73,6 @@ Examples:
 			projectConfig, err := config.LoadProjectConfig(projectFile, git.GetCurrentBranch(), &config.GitOps{
 				HasRef:              git.HasRef,
 				ResolveRef:          git.ResolveRef,
-				SortByGraphOrder:    git.SortRefsByGraphOrder,
 				LocalBranchesOnPath: git.LocalBranchesOnPath,
 			})
 			if err != nil {

--- a/src/config/project.go
+++ b/src/config/project.go
@@ -31,7 +31,8 @@ type ProjectConfig struct {
 	Paths      []string       `yaml:"paths"`
 	Categories []FileCategory `yaml:"categories"`
 	Editor     EditorConfig   `yaml:"editor"`
-	DiffBases  []string       `yaml:"diffbases"`
+	DiffBase   string         `yaml:"diffbase"`
+	DiffBases  []string       `yaml:"-"` // computed: diff base + discovered branches
 	ConfigPath string         `yaml:"-"`
 }
 
@@ -48,7 +49,6 @@ func DefaultProjectConfig() *ProjectConfig {
 			{Name: "test", Patterns: []string{"*_test.go"}},
 			{Name: "hidden", Patterns: []string{".*"}},
 		},
-		DiffBases: []string{"green"},
 	}
 }
 
@@ -57,17 +57,22 @@ func DefaultProjectConfig() *ProjectConfig {
 type GitOps struct {
 	HasRef              func(string) bool
 	ResolveRef          func(string) string
-	SortByGraphOrder    func([]string)
 	LocalBranchesOnPath func(string) []string
 }
 
 // LoadProjectConfig loads the project config from path, falling back to defaults if missing.
 //
-// currentBranch is the current git branch name (used to build default bases).
-// gitOps provides git operations for ref validation, branch discovery, and ordering.
-// When gitOps is nil, DiffBases are left as-is from the config file.
-// The returned config's DiffBases will be the merged result of defaults and configured bases,
-// sorted by graph distance from HEAD (oldest first), with discovered local branches included.
+// currentBranch is the current git branch name.
+// gitOps provides git operations for ref validation and branch discovery.
+// When gitOps is nil, DiffBases are left empty.
+//
+// The DiffBase is resolved as follows:
+//  1. If configured in project.critic, use that value (must exist as a git ref).
+//  2. Otherwise, detect "master" or "main" (whichever exists).
+//  3. If neither exists, return an error.
+//
+// DiffBases is then populated with the diff base plus any local branches
+// discovered on the path from the diff base to HEAD.
 func LoadProjectConfig(path, currentBranch string, gitOps *GitOps) (*ProjectConfig, error) {
 	pc, err := loadProjectConfigFromFile(path)
 	if err != nil {
@@ -75,43 +80,45 @@ func LoadProjectConfig(path, currentBranch string, gitOps *GitOps) (*ProjectConf
 	}
 
 	if gitOps != nil && gitOps.HasRef != nil {
-		allDiffBases := append([]string{"main", "master", "HEAD"}, pc.DiffBases...)
-		unique := lo.Uniq(allDiffBases)
-		candidates := lo.Filter(unique, func(ref string, _ int) bool { return gitOps.HasRef(ref) })
-
-		// Sort candidates by graph order so we can identify the oldest.
-		if gitOps.SortByGraphOrder != nil && len(candidates) > 0 {
-			gitOps.SortByGraphOrder(candidates)
+		// Resolve the single diff base
+		diffBase := pc.DiffBase
+		if diffBase == "" {
+			// Auto-detect: try "master" then "main"
+			for _, candidate := range []string{"master", "main"} {
+				if gitOps.HasRef(candidate) {
+					diffBase = candidate
+					break
+				}
+			}
+			if diffBase == "" {
+				return nil, fmt.Errorf("no diff base configured and neither 'master' nor 'main' branch exists")
+			}
+		} else if !gitOps.HasRef(diffBase) {
+			return nil, fmt.Errorf("configured diff base %q does not exist", diffBase)
 		}
 
-		// Discover local branches on the ancestry path from oldest to HEAD.
-		if gitOps.LocalBranchesOnPath != nil && gitOps.ResolveRef != nil && len(candidates) > 0 {
-			oldest := candidates[0]
-			discovered := gitOps.LocalBranchesOnPath(oldest)
+		pc.DiffBase = diffBase
 
-			// Merge discovered branches, dedup by resolved SHA.
+		// Start with the diff base itself
+		candidates := []string{diffBase}
+
+		// Discover local branches on the path from diff base to HEAD
+		if gitOps.LocalBranchesOnPath != nil {
+			discovered := gitOps.LocalBranchesOnPath(diffBase)
+			candidates = append(candidates, discovered...)
+		}
+
+		// Deduplicate by resolved SHA
+		if gitOps.ResolveRef != nil {
 			seenSHA := make(map[string]bool)
-			var merged []string
-			addRef := func(ref string) {
+			candidates = lo.Filter(candidates, func(ref string, _ int) bool {
 				sha := gitOps.ResolveRef(ref)
 				if seenSHA[sha] {
-					return
+					return false
 				}
 				seenSHA[sha] = true
-				merged = append(merged, ref)
-			}
-			for _, ref := range candidates {
-				addRef(ref)
-			}
-			for _, ref := range discovered {
-				addRef(ref)
-			}
-			candidates = merged
-		}
-
-		// Final sort by graph order, oldest first.
-		if gitOps.SortByGraphOrder != nil {
-			gitOps.SortByGraphOrder(candidates)
+				return true
+			})
 		}
 
 		pc.DiffBases = candidates

--- a/src/config/project_test.go
+++ b/src/config/project_test.go
@@ -65,6 +65,16 @@ project:
 	assert.Nil(t, config.Paths, "paths should be nil")
 	assert.Nil(t, config.Categories, "categories should be nil")
 	assert.Equals(t, config.Editor.URL, "", "editor url should be empty")
+	assert.Equals(t, config.DiffBase, "", "diff base should be empty")
+}
+
+func TestParseProjectConfig_DiffBase(t *testing.T) {
+	yaml := `
+diffbase: master
+`
+	config, err := ParseProjectConfig([]byte(yaml))
+	assert.NoError(t, err)
+	assert.Equals(t, config.DiffBase, "master", "diff base")
 }
 
 func TestParseProjectConfig_InvalidYAML(t *testing.T) {
@@ -82,6 +92,72 @@ func TestDefaultProjectConfig(t *testing.T) {
 	hiddenPatterns := findCategory(config.Categories, "hidden")
 	assert.Equals(t, len(hiddenPatterns), 1, "default hidden patterns")
 	assert.Equals(t, hiddenPatterns[0], ".*", "default hidden pattern")
+	assert.Equals(t, config.DiffBase, "", "default diff base should be empty")
+}
+
+func TestLoadProjectConfig_WithGitOps(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "project.critic")
+	yaml := `
+diffbase: main
+`
+	err := os.WriteFile(path, []byte(yaml), 0644)
+	assert.NoError(t, err)
+
+	gitOps := &GitOps{
+		HasRef:     func(ref string) bool { return ref == "main" },
+		ResolveRef: func(ref string) string { return "sha-" + ref },
+		LocalBranchesOnPath: func(ancestor string) []string {
+			return []string{"feature-a", "feature-b"}
+		},
+	}
+
+	config, err := LoadProjectConfig(path, "feature-b", gitOps)
+	assert.NoError(t, err)
+	assert.Equals(t, config.DiffBase, "main", "diff base")
+	assert.Equals(t, len(config.DiffBases), 3, "should have diff base + 2 discovered branches")
+	assert.Equals(t, config.DiffBases[0], "main", "first should be the configured diff base")
+	assert.Equals(t, config.DiffBases[1], "feature-a", "second should be first discovered branch")
+	assert.Equals(t, config.DiffBases[2], "feature-b", "third should be second discovered branch")
+}
+
+func TestLoadProjectConfig_AutoDetectMaster(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "project.critic")
+	yaml := `
+project:
+  name: "test"
+`
+	err := os.WriteFile(path, []byte(yaml), 0644)
+	assert.NoError(t, err)
+
+	gitOps := &GitOps{
+		HasRef:              func(ref string) bool { return ref == "master" },
+		ResolveRef:          func(ref string) string { return "sha-" + ref },
+		LocalBranchesOnPath: func(ancestor string) []string { return nil },
+	}
+
+	config, err := LoadProjectConfig(path, "", gitOps)
+	assert.NoError(t, err)
+	assert.Equals(t, config.DiffBase, "master", "should auto-detect master")
+}
+
+func TestLoadProjectConfig_NoBranchFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "project.critic")
+	yaml := `
+project:
+  name: "test"
+`
+	err := os.WriteFile(path, []byte(yaml), 0644)
+	assert.NoError(t, err)
+
+	gitOps := &GitOps{
+		HasRef: func(ref string) bool { return false },
+	}
+
+	_, err = LoadProjectConfig(path, "", gitOps)
+	assert.True(t, err != nil, "should fail when no diff base available")
 }
 
 func TestLoadProjectConfig_FileNotFound(t *testing.T) {

--- a/src/git/mergebase.go
+++ b/src/git/mergebase.go
@@ -1,10 +1,9 @@
 package git
 
 import (
-	"math"
-	"sort"
-	"strconv"
 	"strings"
+
+	"github.com/samber/lo"
 )
 
 // GetCurrentBranch returns the name of the current branch
@@ -19,85 +18,65 @@ func IsGitRepo() bool {
 	return err == nil
 }
 
-// graphDistance returns the number of commits between ref and HEAD
-// (i.e., how many commits HEAD is ahead of ref). A larger number means
-// the ref is further back in the graph (older). Returns MaxInt if the
-// ref is not an ancestor of HEAD or cannot be resolved.
-func graphDistance(ref string) int {
-	output, err := tryGit("rev-list", "--count", ref+"..HEAD")
-	if err != nil {
-		return math.MaxInt
-	}
-	n, err := strconv.Atoi(strings.TrimSpace(string(output)))
-	if err != nil {
-		return math.MaxInt
-	}
-	return n
-}
-
-// SortRefsByGraphOrder sorts refs by their topological distance from HEAD,
-// oldest (furthest from HEAD) first. Refs that cannot be resolved are
-// placed at the end.
-func SortRefsByGraphOrder(refs []string) {
-	// Pre-fetch distances so each ref is resolved once.
-	distances := make(map[string]int, len(refs))
-	for _, ref := range refs {
-		distances[ref] = graphDistance(ref)
-	}
-
-	sort.SliceStable(refs, func(i, j int) bool {
-		// Larger distance = further from HEAD = should come first (oldest).
-		return distances[refs[i]] > distances[refs[j]]
-	})
-}
-
-// LocalBranchesOnPath returns all local branch names whose tips are ancestors
-// of HEAD and descendants of (or equal to) ancestorRef, sorted by graph
-// distance from HEAD (oldest first). The ancestorRef itself is excluded from
-// the result if it matches a local branch. HEAD is also excluded since it's
-// always implicitly present.
+// LocalBranchesOnPath returns all local branch names that decorate commits
+// in the range ancestorRef..HEAD, ordered by git log output (newest first).
+// The ancestorRef itself and HEAD are excluded from the result.
+//
+// Uses git log --decorate-refs to efficiently discover branches on the
+// ancestry path without manual sorting.
 func LocalBranchesOnPath(ancestorRef string) []string {
 	if ancestorRef == "" {
 		return nil
 	}
 
-	// Get all local branches merged into HEAD (tips reachable from HEAD).
-	output, err := tryGit("branch", "--merged", "HEAD", "--format=%(refname:short)")
+	// git log --decorate-refs=refs/heads/ --format=%D outputs branch decorations
+	// for each commit in the range, in reverse chronological order.
+	output, err := tryGit("log", "--decorate-refs=refs/heads/", "--format=%D", ancestorRef+"..HEAD")
 	if err != nil {
 		return nil
 	}
 
-	ancestorSHA := ResolveRef(ancestorRef)
-	headSHA := ResolveRef("HEAD")
+	headBranch := GetCurrentBranch()
 
+	// Parse decorations: each line may contain comma-separated branch refs
+	// like "HEAD -> main, feature-branch" or just "feature-branch" or be empty.
+	seen := make(map[string]bool)
 	var result []string
-	for _, branch := range strings.Split(strings.TrimSpace(string(output)), "\n") {
-		branch = strings.TrimSpace(branch)
-		if branch == "" {
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
 			continue
 		}
 
-		branchSHA := ResolveRef(branch)
+		refs := lo.Map(
+			strings.Split(line, ","),
+			func(s string, _ int) string { return strings.TrimSpace(s) },
+		)
 
-		// Skip if the branch tip equals the ancestor (that's our starting point).
-		if branchSHA == ancestorSHA {
-			continue
+		for _, ref := range refs {
+			// Strip "HEAD -> " prefix from decorated refs
+			ref = strings.TrimPrefix(ref, "HEAD -> ")
+
+			if ref == "" || ref == "HEAD" {
+				continue
+			}
+
+			// Skip the current branch (HEAD) and the ancestor ref
+			if ref == headBranch || ref == ancestorRef {
+				continue
+			}
+
+			if !seen[ref] {
+				seen[ref] = true
+				result = append(result, ref)
+			}
 		}
-
-		// Skip HEAD — it's always implicitly included.
-		if branchSHA == headSHA {
-			continue
-		}
-
-		// Branch tip must be a descendant of ancestorRef.
-		_, err := tryGit("merge-base", "--is-ancestor", ancestorRef, branch)
-		if err != nil {
-			continue
-		}
-
-		result = append(result, branch)
 	}
 
-	SortRefsByGraphOrder(result)
+	// Reverse so oldest (furthest from HEAD) comes first, matching git log order
+	lo.Reverse(result)
+
 	return result
 }

--- a/src/git/mergebase_test.go
+++ b/src/git/mergebase_test.go
@@ -6,47 +6,6 @@ import (
 	"github.com/radiospiel/critic/simple-go/assert"
 )
 
-func TestGraphDistance(t *testing.T) {
-	// HEAD has distance 0 from itself.
-	d := graphDistance("HEAD")
-	assert.Equals(t, d, 0, "HEAD should have distance 0 from itself")
-
-	// Invalid ref should return MaxInt.
-	d = graphDistance("nonexistent-ref-xyz")
-	assert.NotEquals(t, d, 0, "invalid ref should not have distance 0")
-}
-
-func TestSortRefsByGraphOrder(t *testing.T) {
-	// Only test with refs that exist in this repo.
-	refs := []string{}
-	for _, candidate := range []string{"master", "main", "HEAD"} {
-		if HasRef(candidate) {
-			refs = append(refs, candidate)
-		}
-	}
-	if len(refs) == 0 {
-		t.Skip("no usable refs found")
-	}
-
-	SortRefsByGraphOrder(refs)
-
-	// Verify distances are non-increasing (oldest/most distant first).
-	for i := 1; i < len(refs); i++ {
-		prev := graphDistance(refs[i-1])
-		curr := graphDistance(refs[i])
-		if prev < curr {
-			t.Errorf("refs not sorted: %s (dist %d) should come after %s (dist %d)",
-				refs[i-1], prev, refs[i], curr)
-		}
-	}
-}
-
-func TestSortRefsByGraphOrder_EmptySlice(t *testing.T) {
-	refs := []string{}
-	SortRefsByGraphOrder(refs)
-	assert.Equals(t, len(refs), 0, "empty slice should stay empty")
-}
-
 func TestLocalBranchesOnPath_EmptyAncestor(t *testing.T) {
 	result := LocalBranchesOnPath("")
 	assert.Nil(t, result, "empty ancestor should return nil")
@@ -68,30 +27,26 @@ func TestLocalBranchesOnPath(t *testing.T) {
 	result := LocalBranchesOnPath(ancestor)
 
 	// Result should not contain the ancestor itself.
-	ancSHA := ResolveRef(ancestor)
 	for _, r := range result {
-		sha := ResolveRef(r)
-		if sha == ancSHA {
-			t.Errorf("result should not contain ancestor %s (sha %s)", ancestor, ancSHA)
+		if r == ancestor {
+			t.Errorf("result should not contain ancestor %s", ancestor)
 		}
 	}
 
-	// Result should not contain HEAD.
-	headSHA := ResolveRef("HEAD")
+	// Result should not contain the current branch (HEAD).
+	headBranch := GetCurrentBranch()
 	for _, r := range result {
-		sha := ResolveRef(r)
-		if sha == headSHA {
-			t.Errorf("result should not contain HEAD (sha %s)", headSHA)
+		if r == headBranch {
+			t.Errorf("result should not contain current branch %s", headBranch)
 		}
 	}
 
-	// Result should be sorted by graph order (oldest/most distant first).
-	for i := 1; i < len(result); i++ {
-		prev := graphDistance(result[i-1])
-		curr := graphDistance(result[i])
-		if prev < curr {
-			t.Errorf("results not sorted: %s (dist %d) should come after %s (dist %d)",
-				result[i-1], prev, result[i], curr)
+	// Result should not contain duplicates.
+	seen := make(map[string]bool)
+	for _, r := range result {
+		if seen[r] {
+			t.Errorf("duplicate branch in result: %s", r)
 		}
+		seen[r] = true
 	}
 }


### PR DESCRIPTION
…(#128)

Simplify diff base configuration from a list to a single value. When no diff base is configured, auto-detect "master" or "main" and fail startup if neither exists.

Replace LocalBranchesOnPath implementation to use
`git log --decorate-refs=refs/heads/ --format=%D` for discovering local branches between the diff base and HEAD, with lo-based filtering. Git output order is preserved directly, removing the need for custom graph-order sorting (SortRefsByGraphOrder and graphDistance removed).

Remove SortByGraphOrder from the GitOps interface since git log output already provides the correct ordering.

Closes #128

https://claude.ai/code/session_01MTpXeMB8wbDFjKYew7esBM