### PR TITLE
Fix category loading, path display, and "Other" label in FileList (#127)

### DIFF
--- a/agents/logs/20260304-100500-fix-category-loading.md
+++ b/agents/logs/20260304-100500-fix-category-loading.md
@@ -1,0 +1,29 @@
+# Task: Fix category loading and prefix display (#127)
+
+**Started:** 2026-03-04 10:05:00
+**Ended:** 2026-03-04 10:15:00
+**Strategy:** Bug Fix
+**Status:** Completed
+**Complexity:** Simple
+**Used Models:** Opus
+**Token usage (Estimated):** 30k input, 5k output
+
+## Objective
+Fix three issues in the FileList component:
+1. Ensure at least one category is always expanded on load
+2. Display category path separately in muted styling instead of inline
+3. Show "Other" instead of "Source" for uncategorized files
+
+## Progress
+- [x] Fix auto-expand: ensure openCategory matches a non-empty section
+- [x] Separate path from label, show in muted styling below
+- [x] Rename "source" display to "Other"
+- [x] Add CSS for file-category-path
+- [x] TypeScript type check passes
+
+## Obstacles
+None.
+
+## Outcome
+FileList now always shows an expanded category on load, displays category paths
+in muted text below the name, and labels uncategorized files as "Other".

--- a/src/webui/frontend/src/components/FileList.tsx
+++ b/src/webui/frontend/src/components/FileList.tsx
@@ -639,15 +639,15 @@ function FileList({ files, allConversations, selectedFile, onSelectFile, onSelec
                 }
               }
 
-              // If only one section, always keep it open
-              if (fileSections.length === 1 && openCategory !== fileSections[0].name) {
+              // Ensure at least one category is always open
+              if (fileSections.length > 0 && !fileSections.some((s) => s.name === openCategory)) {
                 setOpenCategory(fileSections[0].name)
               }
 
               return fileSections.map((section) => {
                 const isOpen = openCategory === section.name
                 const catPath = categoryPaths.get(section.name)
-                const label = section.name.charAt(0).toUpperCase() + section.name.slice(1) + (catPath ? ` (in ${catPath})` : '')
+                const displayName = section.name === 'source' ? 'Other' : section.name.charAt(0).toUpperCase() + section.name.slice(1)
                 let catUnresolved = 0
                 let catExplanations = 0
                 for (const f of section.files) {
@@ -663,7 +663,10 @@ function FileList({ files, allConversations, selectedFile, onSelectFile, onSelec
                       className={`file-category-header${isOpen ? ' open' : ''}`}
                       onClick={() => selectCategory(section.name)}
                     >
-                      <span className="file-category-label">{label} ({pluralize(section.files.length, 'file')})</span>
+                      <span className="file-category-label">
+                        {displayName} ({pluralize(section.files.length, 'file')})
+                        {catPath && <span className="file-category-path">{catPath}</span>}
+                      </span>
                       {catUnresolved > 0 && (
                         <span className="conversation-icon unresolved" title={`${catUnresolved} open`}>
                           {catUnresolved}

--- a/src/webui/frontend/src/index.css
+++ b/src/webui/frontend/src/index.css
@@ -778,6 +778,13 @@ html, body, #root {
   flex: 1;
 }
 
+.file-category-path {
+  display: block;
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
 .file-category-count {
   font-weight: 400;
   font-size: 12px;


### PR DESCRIPTION
- Ensure at least one category is always expanded on load by checking whether the current openCategory matches a non-empty file section
- Display category paths in muted text below the name instead of inline "(in path)" suffix
- Show "Other" instead of "Source" for files that don't match any configured category

Closes #127

https://claude.ai/code/session_01MTpXeMB8wbDFjKYew7esBM